### PR TITLE
chore: tweak runner module invalidate log

### DIFF
--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -104,13 +104,16 @@ function vitePluginReactServer(): PluginOption {
     hotUpdate(ctx) {
       if (ctx.environment.name === "react-server") {
         const ids = ctx.modules.map((mod) => mod.id).filter(typedBoolean);
-        const invalidated =
-          __global.reactServerRunner.moduleCache.invalidateDepTree(ids);
-        debug("[react-server:hotUpdate]", {
-          ids,
-          invalidated: [...invalidated],
-        });
-        return [];
+        if (ids.length > 0) {
+          const invalidated =
+            __global.reactServerRunner.moduleCache.invalidateDepTree(ids);
+          console.log("[react-server:invalidate]", ctx.file);
+          debug("[react-server:hotUpdate]", {
+            ids,
+            invalidated: [...invalidated],
+          });
+          return [];
+        }
       }
       return;
     },

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -84,7 +84,7 @@ function vitePluginReactServer(): PluginOption {
         build: {
           outDir: "dist/react-server",
           sourcemap: true,
-          minify: false,
+          ssr: true,
           rollupOptions: {
             input: {
               index: "/src/entry-react-server",

--- a/examples/react-ssr/vite.config.ts
+++ b/examples/react-ssr/vite.config.ts
@@ -98,11 +98,14 @@ export function vitePluginSsrMiddleware({
     hotUpdate(ctx) {
       if (ctx.environment.name === "ssr") {
         const ids = ctx.modules.map((mod) => mod.id).filter(typedBoolean);
-        const invalidated = runner.moduleCache.invalidateDepTree(ids);
-        debug("[handleUpdate]", { ids, invalidated: [...invalidated] });
-        return [];
+        if (ids.length > 0) {
+          const invalidated = runner.moduleCache.invalidateDepTree(ids);
+          console.log("[ssr:invalidate]", ctx.file);
+          debug("[handleUpdate]", { ids, invalidated: [...invalidated] });
+          return [];
+        }
       }
-      return ctx.modules;
+      return;
     },
 
     configureServer(server) {

--- a/examples/react-ssr/vite.config.ts
+++ b/examples/react-ssr/vite.config.ts
@@ -101,7 +101,7 @@ export function vitePluginSsrMiddleware({
         if (ids.length > 0) {
           const invalidated = runner.moduleCache.invalidateDepTree(ids);
           console.log("[ssr:invalidate]", ctx.file);
-          debug("[handleUpdate]", { ids, invalidated: [...invalidated] });
+          debug("[ssr:handleUpdate]", { ids, invalidated: [...invalidated] });
           return [];
         }
       }


### PR DESCRIPTION
Examples:

Note that client component module also exists in react server as a client reference

```sh
# client component change
[ssr:invalidate] /home/hiroshi/code/personal/vite-environment-examples/examples/react-server/src/routes/_client.tsx
[react-server:invalidate] /home/hiroshi/code/personal/vite-environment-examples/examples/react-server/src/routes/_client.tsx
오후 2:40:59 [vite] hmr update /home/hiroshi/code/personal/vite-environment-examples/examples/react-server/src/routes/_client.tsx

# server component change
[react-server:invalidate] /home/hiroshi/code/personal/vite-environment-examples/examples/react-server/src/routes/page.tsx
```