### PR TITLE
feat(react-server): server component hmr

### DIFF
--- a/examples/react-server/README.md
+++ b/examples/react-server/README.md
@@ -26,7 +26,6 @@ pnpm cf-release
   - [x] build
 - [ ] hmr
   - [x] browser
-  - [ ] server
   - [ ] react-server
 - [ ] integrate to `@hiogawa/react-server`
 

--- a/examples/react-server/README.md
+++ b/examples/react-server/README.md
@@ -24,9 +24,9 @@ pnpm cf-release
 - [x] client reference
   - [x] dev
   - [x] build
-- [ ] hmr
+- [x] hmr
   - [x] browser
-  - [ ] react-server
+  - [x] react-server
 - [ ] integrate to `@hiogawa/react-server`
 
 ## references

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -36,6 +36,12 @@ async function main() {
       reactDomClient.hydrateRoot(rootEl, reactRootEl);
     });
   }
+
+  if (import.meta.hot) {
+    import.meta.hot.on("react-server:update", (e) => {
+      console.log("[react-server] hot update", e);
+    });
+  }
 }
 
 main();

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -25,7 +25,8 @@ async function main() {
 
   function Root() {
     const [streamData, setStreamData] = React.useState(initialStreamData);
-    __setStreamData = setStreamData;
+    const [_isPending, startTransition] = React.useTransition();
+    __setStreamData = (v) => startTransition(() => setStreamData(v));
     return React.use(streamData);
   }
 

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -24,7 +24,8 @@ async function main() {
   let __setStreamData: (v: Promise<StreamData>) => void;
 
   function Root() {
-    const [streamData, __setStreamData] = React.useState(initialStreamData);
+    const [streamData, setStreamData] = React.useState(initialStreamData);
+    __setStreamData = setStreamData;
     return React.use(streamData);
   }
 
@@ -43,7 +44,7 @@ async function main() {
 
   if (import.meta.hot) {
     import.meta.hot.on("react-server:update", (e) => {
-      console.log("[react-server] hot update", e);
+      console.log("[react-server] hot update", e.file);
       const streamData = reactServerDomClient.createFromFetch<StreamData>(
         fetch("/?__rsc"),
         {},

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -14,14 +14,16 @@ async function main() {
     "react-server-dom-webpack/client.browser"
   );
 
-  const rscStream = readRscStreamScript();
-  const rscPromise = reactServerDomClient.createFromReadableStream(
-    rscStream,
+  const initialStreamData = reactServerDomClient.createFromReadableStream(
+    readRscStreamScript(),
     {},
   );
 
+  let __setStreamData: (v: Promise<React.ReactNode>) => void;
+
   function Root() {
-    return React.use(rscPromise);
+    const [streamData, __setStreamData] = React.useState(initialStreamData);
+    return React.use(streamData);
   }
 
   const reactRootEl = <Root />;
@@ -40,6 +42,11 @@ async function main() {
   if (import.meta.hot) {
     import.meta.hot.on("react-server:update", (e) => {
       console.log("[react-server] hot update", e);
+      const streamData = reactServerDomClient.createFromFetch(
+        fetch("/?__rsc"),
+        {},
+      );
+      __setStreamData(streamData);
     });
   }
 }

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import reactDomClient from "react-dom/client";
 import { readRscStreamScript } from "./utils/rsc-stream-script";
 import { initializeWebpackServer } from "./features/use-client/server";
+import type { StreamData } from "./features/stream/utils";
 
 async function main() {
   if (window.location.search.includes("__noCsr")) {
@@ -14,12 +15,13 @@ async function main() {
     "react-server-dom-webpack/client.browser"
   );
 
-  const initialStreamData = reactServerDomClient.createFromReadableStream(
-    readRscStreamScript(),
-    {},
-  );
+  const initialStreamData =
+    reactServerDomClient.createFromReadableStream<StreamData>(
+      readRscStreamScript(),
+      {},
+    );
 
-  let __setStreamData: (v: Promise<React.ReactNode>) => void;
+  let __setStreamData: (v: Promise<StreamData>) => void;
 
   function Root() {
     const [streamData, __setStreamData] = React.useState(initialStreamData);
@@ -42,7 +44,7 @@ async function main() {
   if (import.meta.hot) {
     import.meta.hot.on("react-server:update", (e) => {
       console.log("[react-server] hot update", e);
-      const streamData = reactServerDomClient.createFromFetch(
+      const streamData = reactServerDomClient.createFromFetch<StreamData>(
         fetch("/?__rsc"),
         {},
       );

--- a/examples/react-server/src/entry-server.tsx
+++ b/examples/react-server/src/entry-server.tsx
@@ -6,6 +6,7 @@ import {
   createModuleMap,
   initializeWebpackServer,
 } from "./features/use-client/server";
+import type { StreamData } from "./features/stream/utils";
 
 export async function handler(request: Request) {
   const reactServer = await importReactServer();
@@ -27,12 +28,15 @@ async function renderHtml(rscStream: ReadableStream<Uint8Array>) {
 
   const [rscStream1, rscStream2] = rscStream.tee();
 
-  const rscPromise = reactServerDomClient.createFromReadableStream(rscStream1, {
-    ssrManifest: {
-      moduleMap: createModuleMap(),
-      moduleLoading: null,
+  const rscPromise = reactServerDomClient.createFromReadableStream<StreamData>(
+    rscStream1,
+    {
+      ssrManifest: {
+        moduleMap: createModuleMap(),
+        moduleLoading: null,
+      },
     },
-  });
+  );
 
   function Root() {
     return React.use(rscPromise);

--- a/examples/react-server/src/entry-server.tsx
+++ b/examples/react-server/src/entry-server.tsx
@@ -10,6 +10,11 @@ import {
 export async function handler(request: Request) {
   const reactServer = await importReactServer();
   const rscStream = await reactServer.handler({ request });
+  if (new URL(request.url).searchParams.has("__rsc")) {
+    return new Response(rscStream, {
+      headers: { "content-type": "text/x-component; charset=utf-8" },
+    });
+  }
   const htmlStream = await renderHtml(rscStream);
   return new Response(htmlStream, { headers: { "content-type": "text/html" } });
 }

--- a/examples/react-server/src/features/stream/utils.ts
+++ b/examples/react-server/src/features/stream/utils.ts
@@ -1,0 +1,1 @@
+export type StreamData = React.ReactNode;

--- a/examples/react-server/src/features/use-client/server.ts
+++ b/examples/react-server/src/features/use-client/server.ts
@@ -1,6 +1,13 @@
 import { memoize, tinyassert } from "@hiogawa/utils";
 import type { ImportManifestEntry, ModuleMap } from "../../types";
 
+// In contrast to old dev ssr, new module runner's dynamic `import`
+// with `vite-ignore` joins in a module graph.
+// Thus, `invalidateDepTree` by `vitePluginReactServer` will invalidate
+// this entire module and `momoize` will get refreshed automatically.
+// So, we don't have to manage `ssrImportPromiseCache` like done in
+// https://github.com/hi-ogawa/vite-plugins/blob/1c12519065563da60de9f58b946695adcbb50924/packages/react-server/src/features/use-client/server.tsx#L10-L18
+
 async function importWrapper(id: string) {
   if (import.meta.env.DEV) {
     return import(/* @vite-ignore */ id);

--- a/examples/react-server/src/types/react.d.ts
+++ b/examples/react-server/src/types/react.d.ts
@@ -4,8 +4,8 @@ declare module "react-dom/server.edge" {
 
 // https://github.com/facebook/react/blob/89021fb4ec9aa82194b0788566e736a4cedfc0e4/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
 declare module "react-server-dom-webpack/server.edge" {
-  export function renderToReadableStream(
-    node: React.ReactNode,
+  export function renderToReadableStream<T>(
+    data: T,
     bundlerConfig: import(".").BundlerConfig,
     opitons?: {
       onError: import("react-dom/server").RenderToReadableStreamOptions["onError"];
@@ -17,31 +17,31 @@ declare module "react-server-dom-webpack/server.edge" {
 
 // https://github.com/facebook/react/blob/89021fb4ec9aa82194b0788566e736a4cedfc0e4/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
 declare module "react-server-dom-webpack/client.edge" {
-  export function createFromReadableStream(
+  export function createFromReadableStream<T>(
     stream: ReadableStream<Uint8Array>,
     options: {
       ssrManifest: import(".").SsrManifest;
       // TODO
       // encodeFormAction
     },
-  ): Promise<React.ReactNode>;
+  ): Promise<T>;
 }
 
 // https://github.com/facebook/react/blob/89021fb4ec9aa82194b0788566e736a4cedfc0e4/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
 declare module "react-server-dom-webpack/client.browser" {
-  export function createFromReadableStream(
+  export function createFromReadableStream<T>(
     stream: ReadableStream<Uint8Array>,
     options?: {
       callServer?: import(".").CallServerCallback;
     },
-  ): Promise<React.ReactNode>;
+  ): Promise<T>;
 
-  export function createFromFetch(
+  export function createFromFetch<T>(
     promiseForResponse: Promise<Response>,
     options?: {
       callServer?: import(".").CallServerCallback;
     },
-  ): Promise<React.ReactNode>;
+  ): Promise<T>;
 
   export function encodeReply(
     v: unknown,

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -107,10 +107,17 @@ function vitePluginReactServer(): PluginOption {
         if (ids.length > 0) {
           const invalidated =
             __global.reactServerRunner.moduleCache.invalidateDepTree(ids);
-          console.log("[react-server:invalidate]", ctx.file);
           debug("[react-server:hotUpdate]", {
             ids,
             invalidated: [...invalidated],
+          });
+          console.log("[react-server:hmr]", ctx.file);
+          __global.server.environments.client.hot.send({
+            type: "custom",
+            event: "react-server:update",
+            data: {
+              file: ctx.file,
+            },
           });
           return [];
         }


### PR DESCRIPTION
While doing this, I found one case client component state cannot be preserved on server component hmr:
- increment counter in `_client.tsx`
- update `page.tsx` (counter preserved)
- update `_client.tsx` (counter preserved)
- update `page.tsx` (counter reset)

It looks like this is because the stream includes an client reference without `?t=...` and that's somehow making React to re-mount the client component even though such client component properly loads fresh module.

TODO: test case to be added on react-server repo