### PR TITLE
feat(workerd): support custom serialization

### DIFF
--- a/examples/workerd-cli/src/cli.ts
+++ b/examples/workerd-cli/src/cli.ts
@@ -11,16 +11,16 @@ async function main() {
     clearScreen: false,
     plugins: [
       {
-        name: "virtual-repl",
+        name: "virtual-eval",
         resolveId(source, _importer, _options) {
-          if (source.startsWith("virtual:repl/")) {
+          if (source.startsWith("virtual:eval/")) {
             return "\0" + source;
           }
           return;
         },
         load(id, _options) {
-          if (id.startsWith("\0virtual:repl/")) {
-            const cmd = id.slice("\0virtual:repl/".length);
+          if (id.startsWith("\0virtual:eval/")) {
+            const cmd = id.slice("\0virtual:eval/".length);
             return decodeURI(cmd);
           }
           return;
@@ -54,7 +54,7 @@ async function main() {
       cmd = `return ${cmd}`;
     }
     const entrySource = `export default async function(env) { ${cmd} };`;
-    const entry = "virtual:repl/" + encodeURI(entrySource);
+    const entry = "virtual:eval/" + encodeURI(entrySource);
     await devEnv.api.eval(
       entry,
       async function (ctx) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm '--filter=./packages/*' build",
-    "tsc": "tsc -b examples/*/tsconfig.json",
+    "tsc": "tsc -b packages/*/tsconfig.json examples/*/tsconfig.json",
     "tsc-dev": "pnpm tsc --watch --preserveWatchOutput",
     "lint": "prettier -w --cache .",
     "lint-check": "prettier -c --cache ."

--- a/packages/workerd/src/plugin.ts
+++ b/packages/workerd/src/plugin.ts
@@ -12,9 +12,10 @@ import {
   ANY_URL,
   RUNNER_INIT_PATH,
   setRunnerFetchOptions,
-  type RunnerEvalOptions,
   RUNNER_EVAL_PATH,
   type RunnerEvalFn,
+  encodeEvalRequest,
+  decodeEvalResponse,
 } from "./shared";
 import {
   DevEnvironment,
@@ -59,6 +60,29 @@ export function vitePluginWorkerd(pluginOptions: WorkerdPluginOptions): Plugin {
         return;
       }
       const devEnv = server.environments["workerd"] as WorkerdDevEnvironment;
+      // devEnv.api.eval2(entry, (ctx) => {}, )
+      // serialization can be moved
+      // import { serialize, deserialize } from "deser";
+      // export function f() {}
+      //
+
+      // const nodeMiddleware = createMiddleware(
+      //   (ctx) =>
+      //     devEnv.api.eval2(
+      //       entry,
+      //       (evalCtx) => {
+      //         // const { deserialize, serialize } = await import("serialization-lib");
+      //         // const args = await deserialize(rawArgs);
+      //         // const result = await mod.default(...args);
+      //         // return await serialize(result);
+
+      //         evalCtx.exports["default"](evalCtx.args[0]);
+      //         // evalCtx.args[0];
+      //       },
+      //       ctx.request,
+      //     ),
+      //   { alwaysCallNext: false },
+      // );
       const nodeMiddleware = createMiddleware(
         (ctx) => devEnv.api.dispatchFetch(entry, ctx.request),
         { alwaysCallNext: false },
@@ -190,18 +214,17 @@ export async function createWorkerdDevEnvironment(
     },
 
     // playwright-like eval interface https://playwright.dev/docs/evaluating
-    // (de)serialization can be customized (currently JSON.stringify/parse)
     async eval(entry: string, fn: RunnerEvalFn, ...args: any[]): Promise<any> {
+      const encoded = await encodeEvalRequest({
+        entry,
+        fnString: fn.toString(),
+        args,
+      });
       const res = await runnerObject.fetch(ANY_URL + RUNNER_EVAL_PATH, {
         method: "POST",
-        body: JSON.stringify({
-          entry,
-          fnString: fn.toString(),
-          args,
-        } satisfies RunnerEvalOptions),
+        ...encoded,
       });
-      tinyassert(res.ok);
-      return (await res.json()) as any;
+      return decodeEvalResponse(res as any as Response);
     },
   };
 

--- a/packages/workerd/src/worker.ts
+++ b/packages/workerd/src/worker.ts
@@ -5,7 +5,6 @@ import {
   getRunnerFetchOptions,
   type RunnerEnv,
   RUNNER_EVAL_PATH,
-  type RunnerEvalOptions,
   type RunnerEvalFn,
   decodeEvalRequest,
   encodeEvalResponse,


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/vite-environment-examples/pull/23

It looks like `seroval` https://github.com/lxsmnsyc/seroval is already into serializing entire `Request/Response`, so that may be it?