### PR TITLE
refactor(vue): use suspense

### DIFF
--- a/examples/vue-ssr-extra/src/features/server-action/shared.ts
+++ b/examples/vue-ssr-extra/src/features/server-action/shared.ts
@@ -74,6 +74,7 @@ function submitEventToFormData(e: SubmitEvent) {
   return formData;
 }
 
+// TODO: action return value on progressive enhancement?
 export function useEnhance<T>(
   action: FormAction<T>,
   options?: {

--- a/examples/vue-ssr-extra/src/root.vue
+++ b/examples/vue-ssr-extra/src/root.vue
@@ -10,6 +10,8 @@ onMounted(() => {
 onUpdated(() => {
   updated.value++;
 });
+
+const suspended = ref(false);
 </script>
 
 <template>
@@ -21,6 +23,7 @@ onUpdated(() => {
     >
       GitHub
     </a>
+    <span v-if="suspended">...</span>
   </div>
   <div style="display: flex; align-items: center; gap: 0.5rem">
     mounted: {{ mounted }}, updated: {{ mounted }}
@@ -34,15 +37,17 @@ onUpdated(() => {
       <li>
         <RouterLink to="/client">Counter (client)</RouterLink>
       </li>
-      <li style="display: flex; gap: 0.5rem">
-        <RouterLink to="/server">Counter (server)</RouterLink>
-        <a href="/server?__nojs">(disable js)</a>
+      <li>
+        <span style="display: flex; gap: 0.5rem">
+          <RouterLink to="/server">Counter (server)</RouterLink>
+          <a href="/server?__nojs">(disable js)</a>
+        </span>
       </li>
     </ul>
   </nav>
   <main>
     <RouterView v-slot="{ Component }">
-      <Suspense>
+      <Suspense @pending="suspended = true" @resolve="suspended = false">
         <component :is="Component"></component>
       </Suspense>
     </RouterView>

--- a/examples/vue-ssr-extra/src/root.vue
+++ b/examples/vue-ssr-extra/src/root.vue
@@ -41,6 +41,10 @@ onUpdated(() => {
     </ul>
   </nav>
   <main>
-    <RouterView />
+    <RouterView v-slot="{ Component }">
+      <Suspense>
+        <component :is="Component"></component>
+      </Suspense>
+    </RouterView>
   </main>
 </template>

--- a/examples/vue-ssr-extra/src/routes/server/page.vue
+++ b/examples/vue-ssr-extra/src/routes/server/page.vue
@@ -3,6 +3,7 @@ import { useServerCounter } from "./_store";
 import { Form, useEnhance } from "../../features/server-action/shared";
 import { changeCounter, getCounter } from "./_action";
 
+// TODO: revalidation
 const store = useServerCounter();
 store.data ??= await getCounter();
 

--- a/examples/vue-ssr-extra/src/routes/server/page.vue
+++ b/examples/vue-ssr-extra/src/routes/server/page.vue
@@ -1,20 +1,10 @@
 <script setup lang="ts">
-import { onMounted, onServerPrefetch } from "vue";
 import { useServerCounter } from "./_store";
 import { Form, useEnhance } from "../../features/server-action/shared";
 import { changeCounter, getCounter } from "./_action";
 
 const store = useServerCounter();
-
-// TODO: suspend?
-onServerPrefetch(async () => {
-  store.data = await getCounter();
-});
-
-onMounted(async () => {
-  // TODO: refetch on stale?
-  store.data ??= await getCounter();
-});
+store.data ??= await getCounter();
 
 const [formAction, { status }] = useEnhance(changeCounter, {
   onSuccess(data) {

--- a/examples/vue-ssr-extra/src/routes/server/page.vue
+++ b/examples/vue-ssr-extra/src/routes/server/page.vue
@@ -4,8 +4,6 @@ import { Form, useEnhance } from "../../features/server-action/shared";
 import { changeCounter, getCounter } from "./_action";
 
 const store = useServerCounter();
-
-// TODO: tanstack-query-like stale refetch?
 store.data ??= await getCounter();
 
 const [formAction, { status }] = useEnhance(changeCounter, {

--- a/examples/vue-ssr-extra/src/routes/server/page.vue
+++ b/examples/vue-ssr-extra/src/routes/server/page.vue
@@ -4,6 +4,8 @@ import { Form, useEnhance } from "../../features/server-action/shared";
 import { changeCounter, getCounter } from "./_action";
 
 const store = useServerCounter();
+
+// TODO: tanstack-query-like stale refetch?
 store.data ??= await getCounter();
 
 const [formAction, { status }] = useEnhance(changeCounter, {


### PR DESCRIPTION
I was surprised by `onServerPrefetch`, but maybe async component also just works.

## todo

- pending state of suspended transition?

This is nice:
https://vuejs.org/guide/built-ins/suspense.html#loading-state

> When a revert happens, fallback content will not be immediately displayed. Instead, <Suspense> will display the previous #default content while waiting for the new content and its async dependencies to be resolved. 

So, probably we can just check suspense events to manage pending state outside?
https://vuejs.org/guide/built-ins/suspense.html#events