### PR TITLE
test(vue): flaky outdated deps

### DIFF
--- a/examples/vue-ssr-extra/vite.config.ts
+++ b/examples/vue-ssr-extra/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig((_env) => ({
       },
       dev: {
         optimizeDeps: {
-          include: [],
+          include: ["pinia", "vue-router", "vue"],
         },
       },
       build: {

--- a/examples/vue-ssr-extra/vite.config.ts
+++ b/examples/vue-ssr-extra/vite.config.ts
@@ -41,7 +41,9 @@ export default defineConfig((_env) => ({
       },
       dev: {
         optimizeDeps: {
-          include: ["pinia", "vue-router", "vue"],
+          // prevent flaky outdated deps error
+          noDiscovery: true,
+          include: [],
         },
       },
       build: {


### PR DESCRIPTION
It looks like something is flaky:
https://github.com/hi-ogawa/vite-environment-examples/actions/runs/8746298507/job/24002899390

```
[WebServer] [fetchModule] [
  '/@fs/home/runner/work/vite-environment-examples/vite-environment-examples/node_modules/.pnpm/@vue+devtools-api@6.6.1/node_modules/@vue/devtools-api/lib/esm/api/api.js',
  '/home/runner/work/vite-environment-examples/vite-environment-examples/node_modules/.pnpm/@vue+devtools-api@6.6.1/node_modules/@vue/devtools-api/lib/esm/api/index.js'
] Error: There is a new version of the pre-bundle for "/home/runner/work/vite-environment-examples/vite-environment-examples/node_modules/.pnpm/@vue+devtools-api@6.6.1/node_modules/@vue/devtools-api/lib/esm/api/api.js", a page reload is going to ask for it.
    at throwOutdatedRequest (file:///home/runner/work/vite-environment-examples/vite-environment-examples/node_modules/.pnpm/vite@6.0.0-alpha.2_@types+node@20.11.30/node_modules/vite/dist/node/chunks/dep-E4cF1RpV.js:36727:[17](https://github.com/hi-ogawa/vite-environment-examples/actions/runs/8746298507/job/24002899390#step:24:18))
    at TransformContext.transform (file:///home/runner/work/vite-environment-examples/vite-environment-examples/node_modules/.pnpm/vite@6.0.0-alpha.2_@types+node@20.11.30/node_modules/vite/dist/node/chunks/dep-E4cF1RpV.js:60353:17)
    at async Object.transform (file:///home/runner/work/vite-environment-examples/vite-environment-examples/node_modules/.pnpm/vite@6.0.0-alpha.2_@types+node@20.11.30/node_modules/vite/dist/node/chunks/dep-E4cF1RpV.js:63079:30)
    at async loadAndTransform (file:///home/runner/work/vite-environment-examples/vite-environment-examples/node_modules/.pnpm/vite@6.0.0-alpha.2_@types+node@[20](https://github.com/hi-ogawa/vite-environment-examples/actions/runs/8746298507/job/24002899390#step:24:21).11.30/node_modules/vite/dist/node/chunks/dep-E4cF1RpV.js:54211:29) {
  code: 'ERR_OUTDATED_OPTIMIZED_DEP',
  plugin: 'vite:import-analysis',
  id: '/home/runner/work/vite-environment-examples/vite-environment-examples/node_modules/.pnpm/@vue+devtools-api@6.6.1/node_modules/@vue/devtools-api/lib/esm/api/api.js',
  pluginCode: 'export {};\n'
}
```

This was once reproducible in https://github.com/vitejs/vite/pull/16426, but the latest branch seems to be fine.