### PR TITLE
refactor(react-server): rename global name

### DIFF
--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -4,11 +4,11 @@ import reactDomClient from "react-dom/client";
 import { readRscStreamScript } from "./utils/rsc-stream-script";
 import { initializeWebpackBrowser } from "./features/use-client/browser";
 import type { StreamData } from "./entry-react-server";
-import { __global } from "./global";
+import { $__global } from "./global";
 import { injectActionId } from "./features/server-action/utils";
 
 async function main() {
-  if (window.location.search.includes("__noCsr")) {
+  if (window.location.search.includes("__nojs")) {
     return;
   }
 
@@ -17,14 +17,14 @@ async function main() {
     "react-server-dom-webpack/client.browser"
   );
 
-  __global.callServer = (id, args) => {
+  $__global.callServer = (id, args) => {
     tinyassert(args.length === 1);
     tinyassert(args[0] instanceof FormData);
     const body = args[0];
     injectActionId(body, id);
     const streamData = reactServerDomClient.createFromFetch<StreamData>(
       fetch("/?__rsc", { method: "POST", body }),
-      { callServer: __global.callServer },
+      { callServer: $__global.callServer },
     );
     __setStreamData(streamData);
   };
@@ -32,7 +32,7 @@ async function main() {
   const initialStreamData =
     reactServerDomClient.createFromReadableStream<StreamData>(
       readRscStreamScript(),
-      { callServer: __global.callServer },
+      { callServer: $__global.callServer },
     );
 
   let __setStreamData: (v: Promise<StreamData>) => void;
@@ -62,7 +62,7 @@ async function main() {
       console.log("[react-server] hot update", e.file);
       const streamData = reactServerDomClient.createFromFetch<StreamData>(
         fetch("/?__rsc"),
-        { callServer: __global.callServer },
+        { callServer: $__global.callServer },
       );
       __setStreamData(streamData);
     });

--- a/examples/react-server/src/entry-server.tsx
+++ b/examples/react-server/src/entry-server.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { __global } from "./global";
+import { $__global } from "./global";
 import reactDomServer from "react-dom/server.edge";
 import { injectRscStreamScript } from "./utils/rsc-stream-script";
 import {
@@ -54,7 +54,7 @@ async function renderHtml(rscStream: ReadableStream<Uint8Array>) {
 async function importReactServer() {
   let mod: typeof import("./entry-react-server");
   if (import.meta.env.DEV) {
-    mod = (await __global.reactServerRunner.import(
+    mod = (await $__global.reactServerRunner.import(
       "/src/entry-react-server",
     )) as any;
   } else {
@@ -66,7 +66,7 @@ async function importReactServer() {
 async function importHtmlTemplate() {
   if (import.meta.env.DEV) {
     const mod = await import("/index.html?raw");
-    return __global.server.transformIndexHtml("/", mod.default);
+    return $__global.server.transformIndexHtml("/", mod.default);
   } else {
     const mod = await import("/dist/client/index.html?raw");
     return mod.default;

--- a/examples/react-server/src/features/server-action/browser.ts
+++ b/examples/react-server/src/features/server-action/browser.ts
@@ -1,8 +1,8 @@
 import reactServerDomClient from "react-server-dom-webpack/client.browser";
-import { __global } from "../../global";
+import { $__global } from "../../global";
 
 export function createServerReference(id: string) {
   return reactServerDomClient.createServerReference(id, (...args) =>
-    __global.callServer(...args),
+    $__global.callServer(...args),
   );
 }

--- a/examples/react-server/src/global.tsx
+++ b/examples/react-server/src/global.tsx
@@ -4,7 +4,7 @@ import type { CallServerCallback } from "./types";
 
 // quick global hacks...
 
-export const __global: {
+export const $__global: {
   server: ViteDevServer;
   reactServerRunner: ModuleRunner;
   callServer: CallServerCallback;

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -6,7 +6,7 @@ import {
   createServerModuleRunner,
 } from "vite";
 import { createDebug, tinyassert, typedBoolean } from "@hiogawa/utils";
-import { __global } from "./src/global";
+import { $__global } from "./src/global";
 import react from "@vitejs/plugin-react";
 import { vitePluginSsrMiddleware } from "../react-ssr/vite.config";
 import {
@@ -103,15 +103,15 @@ function vitePluginReactServer(): PluginOption {
       const reactServerEnv = server.environments["react-server"];
       tinyassert(reactServerEnv);
       const reactServerRunner = createServerModuleRunner(reactServerEnv);
-      __global.server = server;
-      __global.reactServerRunner = reactServerRunner;
+      $__global.server = server;
+      $__global.reactServerRunner = reactServerRunner;
     },
     hotUpdate(ctx) {
       if (ctx.environment.name === "react-server") {
         const ids = ctx.modules.map((mod) => mod.id).filter(typedBoolean);
         if (ids.length > 0) {
           const invalidated =
-            __global.reactServerRunner.moduleCache.invalidateDepTree(ids);
+            $__global.reactServerRunner.moduleCache.invalidateDepTree(ids);
           debug("[react-server:hotUpdate]", {
             ids,
             invalidated: [...invalidated],
@@ -120,7 +120,7 @@ function vitePluginReactServer(): PluginOption {
           // but we skip RSC HMR for this case since Client HMR handles it.
           if (!ids.some((id) => manager.clientReferences.has(id))) {
             console.log("[react-server:hmr]", ctx.file);
-            __global.server.environments.client.hot.send({
+            $__global.server.environments.client.hot.send({
               type: "custom",
               event: "react-server:update",
               data: {


### PR DESCRIPTION
Since tsc allows unused var of `__global`, I sometimes forget to remove it. Let's avoid underscore prefix.