### PR TITLE
feat(react-server): support `React.useActionState`

### DIFF
--- a/examples/react-server/README.md
+++ b/examples/react-server/README.md
@@ -31,4 +31,4 @@ pnpm cf-release
   - [x] react-server
 - [ ] server action
   - [x] basic form action
-  - [ ] `encodeReply/decodeReply/decodeAction/decodeFormState/useActionState`
+  - [ ] `encodeReply/decodeReply/useActionState/decodeAction/decodeFormState`

--- a/examples/react-server/README.md
+++ b/examples/react-server/README.md
@@ -29,6 +29,6 @@ pnpm cf-release
 - [x] hmr
   - [x] browser
   - [x] react-server
-- [ ] server action
+- [x] server action
   - [x] basic form action
-  - [ ] `encodeReply/decodeReply/decodeAction/decodeFormState/useActionState`
+  - [x] `encodeReply/decodeReply/decodeAction/decodeFormState/useActionState`

--- a/examples/react-server/README.md
+++ b/examples/react-server/README.md
@@ -1,5 +1,8 @@
 # react-server
 
+Porting [`@hiogawa/react-server`](https://github.com/hi-ogawa/vite-plugins/tree/main/packages/react-server) (single process / two Vite servers)
+to Vite 6 environment API (single process / single Vite server)
+
 https://vite-environment-examples-react-server.hiro18181.workers.dev/
 
 ```sh
@@ -26,9 +29,6 @@ pnpm cf-release
 - [x] hmr
   - [x] browser
   - [x] react-server
-- [x] server action
-- [ ] integrate to `@hiogawa/react-server`
-
-## references
-
-- https://github.com/hi-ogawa/vite-plugins/tree/main/packages/react-server
+- [ ] server action
+  - [x] basic form action
+  - [ ] `encodeReply/decodeReply/decodeAction/decodeFormState/useActionState`

--- a/examples/react-server/README.md
+++ b/examples/react-server/README.md
@@ -31,4 +31,4 @@ pnpm cf-release
   - [x] react-server
 - [ ] server action
   - [x] basic form action
-  - [ ] `encodeReply/decodeReply/useActionState/decodeAction/decodeFormState`
+  - [ ] `encodeReply/decodeReply/decodeAction/decodeFormState/useActionState`

--- a/examples/react-server/e2e/basic.test.ts
+++ b/examples/react-server/e2e/basic.test.ts
@@ -1,4 +1,4 @@
-import { test, type Page } from "@playwright/test";
+import { test, type Page, expect } from "@playwright/test";
 
 test("client-component", async ({ page }) => {
   await page.goto("/");
@@ -35,4 +35,31 @@ async function testServerAction(page: Page) {
     .getByRole("button", { name: "-" })
     .click();
   await page.getByTestId("server-action").getByText("Count: 0").click();
+}
+
+test("useActionState @js", async ({ page }) => {
+  await page.goto("/");
+  await page.getByText("hydrated: true").click();
+  await testUseActionState(page, { js: true });
+});
+
+test("useActionState @nojs", async ({ browser }) => {
+  const page = await browser.newPage({ javaScriptEnabled: false });
+  await page.goto("/");
+  await testUseActionState(page, { js: false });
+});
+
+async function testUseActionState(page: Page, options: { js: boolean }) {
+  await page.getByPlaceholder("Answer?").fill("3");
+  await page.getByPlaceholder("Answer?").press("Enter");
+  if (options.js) {
+    await expect(page.getByTestId("action-state")).toHaveText("...");
+  }
+  await page.getByText("Wrong! (tried once)").click();
+  await expect(page.getByPlaceholder("Answer?")).toHaveValue(
+    options.js ? "3" : "",
+  );
+  await page.getByPlaceholder("Answer?").fill("2");
+  await page.getByPlaceholder("Answer?").press("Enter");
+  await page.getByText("Correct! (tried 2 times)").click();
 }

--- a/examples/react-server/package.json
+++ b/examples/react-server/package.json
@@ -13,9 +13,9 @@
     "cf-release": "cd misc/cloudflare-workers && wrangler deploy"
   },
   "dependencies": {
-    "react": "18.3.0-canary-6c3b8dbfe-20240226",
-    "react-dom": "18.3.0-canary-6c3b8dbfe-20240226",
-    "react-server-dom-webpack": "18.3.0-canary-6c3b8dbfe-20240226"
+    "react": "19.0.0-canary-4c12339ce-20240408",
+    "react-dom": "19.0.0-canary-4c12339ce-20240408",
+    "react-server-dom-webpack": "19.0.0-canary-4c12339ce-20240408"
   },
   "devDependencies": {
     "@hiogawa/vite-plugin-ssr-middleware-alpha": "workspace:*",

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -5,7 +5,6 @@ import { readRscStreamScript } from "./utils/rsc-stream-script";
 import { initializeWebpackBrowser } from "./features/use-client/browser";
 import type { StreamData } from "./entry-react-server";
 import { $__global } from "./global";
-import { injectActionId } from "./features/server-action/utils";
 
 async function main() {
   if (window.location.search.includes("__nojs")) {
@@ -18,12 +17,11 @@ async function main() {
   );
 
   $__global.callServer = async (id, args) => {
-    tinyassert(args.length === 1);
-    tinyassert(args[0] instanceof FormData);
-    const body = args[0];
-    injectActionId(body, id);
     const streamData = reactServerDomClient.createFromFetch<StreamData>(
-      fetch("/?__rsc", { method: "POST", body }),
+      fetch("/?__stream&__action_id=" + encodeURIComponent(id), {
+        method: "POST",
+        body: await reactServerDomClient.encodeReply(args),
+      }),
       { callServer: $__global.callServer },
     );
     $__setStreamData(streamData);
@@ -62,7 +60,7 @@ async function main() {
     import.meta.hot.on("react-server:update", (e) => {
       console.log("[react-server] hot update", e.file);
       const streamData = reactServerDomClient.createFromFetch<StreamData>(
-        fetch("/?__rsc"),
+        fetch("/?__stream"),
         { callServer: $__global.callServer },
       );
       $__setStreamData(streamData);

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -25,7 +25,7 @@ async function main() {
       { callServer: $__global.callServer },
     );
     $__setStreamData(streamData);
-    return (await streamData).actionState;
+    return (await streamData).actionResult;
   };
 
   const initialStreamData =
@@ -51,8 +51,12 @@ async function main() {
   if (window.location.search.includes("__noHydrate")) {
     reactDomClient.createRoot(rootEl).render(reactRootEl);
   } else {
+    // TODO: can we avoid await? (separate script stream?)
+    const formState = (await initialStreamData).actionResult;
     React.startTransition(() => {
-      reactDomClient.hydrateRoot(rootEl, reactRootEl);
+      reactDomClient.hydrateRoot(rootEl, reactRootEl, {
+        formState,
+      });
     });
   }
 
@@ -65,6 +69,13 @@ async function main() {
       );
       $__setStreamData(streamData);
     });
+  }
+}
+
+// formState not typed yet
+declare module "react-dom/client" {
+  interface HydrationOptions {
+    formState: unknown;
   }
 }
 

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -72,11 +72,4 @@ async function main() {
   }
 }
 
-// formState not typed yet
-declare module "react-dom/client" {
-  interface HydrationOptions {
-    formState: unknown;
-  }
-}
-
 main();

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -17,7 +17,7 @@ async function main() {
     "react-server-dom-webpack/client.browser"
   );
 
-  $__global.callServer = (id, args) => {
+  $__global.callServer = async (id, args) => {
     tinyassert(args.length === 1);
     tinyassert(args[0] instanceof FormData);
     const body = args[0];
@@ -26,7 +26,8 @@ async function main() {
       fetch("/?__rsc", { method: "POST", body }),
       { callServer: $__global.callServer },
     );
-    __setStreamData(streamData);
+    $__setStreamData(streamData);
+    return (await streamData).actionState;
   };
 
   const initialStreamData =
@@ -35,13 +36,13 @@ async function main() {
       { callServer: $__global.callServer },
     );
 
-  let __setStreamData: (v: Promise<StreamData>) => void;
+  let $__setStreamData: (v: Promise<StreamData>) => void;
 
   function Root() {
     const [streamData, setStreamData] = React.useState(initialStreamData);
     const [_isPending, startTransition] = React.useTransition();
-    __setStreamData = (v) => startTransition(() => setStreamData(v));
-    return React.use(streamData);
+    $__setStreamData = (v) => startTransition(() => setStreamData(v));
+    return React.use(streamData).node;
   }
 
   const reactRootEl = <Root />;
@@ -64,7 +65,7 @@ async function main() {
         fetch("/?__rsc"),
         { callServer: $__global.callServer },
       );
-      __setStreamData(streamData);
+      $__setStreamData(streamData);
     });
   }
 }

--- a/examples/react-server/src/entry-react-server.tsx
+++ b/examples/react-server/src/entry-react-server.tsx
@@ -5,13 +5,22 @@ import { serverActionHandler } from "./features/server-action/react-server";
 
 export type StreamData = {
   node: React.ReactNode;
-  actionState?: unknown;
+  actionResult?: unknown;
 };
 
-export async function handler({ request }: { request: Request }) {
-  let actionState: unknown;
+export interface ReactServerHandlerResult {
+  stream: ReadableStream<Uint8Array>;
+  actionResult?: unknown;
+}
+
+export async function handler({
+  request,
+}: {
+  request: Request;
+}): Promise<ReactServerHandlerResult> {
+  let actionResult: unknown;
   if (request.method === "POST") {
-    actionState = await serverActionHandler({ request });
+    actionResult = await serverActionHandler({ request });
   }
 
   const node = <Page />;
@@ -19,10 +28,10 @@ export async function handler({ request }: { request: Request }) {
   const stream = reactServerDomServer.renderToReadableStream<StreamData>(
     {
       node,
-      actionState,
+      actionResult: actionResult,
     },
     createBundlerConfig(),
   );
 
-  return stream;
+  return { stream, actionResult };
 }

--- a/examples/react-server/src/entry-react-server.tsx
+++ b/examples/react-server/src/entry-react-server.tsx
@@ -3,17 +3,24 @@ import Page from "./routes/page";
 import { createBundlerConfig } from "./features/use-client/react-server";
 import { serverActionHandler } from "./features/server-action/react-server";
 
-export type StreamData = React.ReactNode;
+export type StreamData = {
+  node: React.ReactNode;
+  actionState?: unknown;
+};
 
 export async function handler({ request }: { request: Request }) {
+  let actionState: unknown;
   if (request.method === "POST") {
-    await serverActionHandler({ request });
+    actionState = await serverActionHandler({ request });
   }
 
-  const root = <Page />;
+  const node = <Page />;
 
   const stream = reactServerDomServer.renderToReadableStream<StreamData>(
-    root,
+    {
+      node,
+      actionState,
+    },
     createBundlerConfig(),
   );
 

--- a/examples/react-server/src/entry-server.tsx
+++ b/examples/react-server/src/entry-server.tsx
@@ -11,7 +11,7 @@ import type { StreamData } from "./entry-react-server";
 export async function handler(request: Request) {
   const reactServer = await importReactServer();
   const rscStream = await reactServer.handler({ request });
-  if (new URL(request.url).searchParams.has("__rsc")) {
+  if (new URL(request.url).searchParams.has("__stream")) {
     return new Response(rscStream, {
       headers: { "content-type": "text/x-component; charset=utf-8" },
     });

--- a/examples/react-server/src/entry-server.tsx
+++ b/examples/react-server/src/entry-server.tsx
@@ -39,7 +39,7 @@ async function renderHtml(rscStream: ReadableStream<Uint8Array>) {
   );
 
   function Root() {
-    return React.use(rscPromise);
+    return React.use(rscPromise).node;
   }
 
   const ssrStream = await reactDomServer.renderToReadableStream(<Root />);

--- a/examples/react-server/src/entry-server.tsx
+++ b/examples/react-server/src/entry-server.tsx
@@ -56,12 +56,6 @@ async function renderHtml(result: ReactServerHandlerResult) {
     .pipeThrough(new TextEncoderStream());
 }
 
-// formState not typed yet
-declare module "react-dom/server" {
-  interface RenderToReadableStreamOptions {
-    formState: unknown;
-  }
-}
 
 async function importReactServer() {
   let mod: typeof import("./entry-react-server");

--- a/examples/react-server/src/entry-server.tsx
+++ b/examples/react-server/src/entry-server.tsx
@@ -56,7 +56,6 @@ async function renderHtml(result: ReactServerHandlerResult) {
     .pipeThrough(new TextEncoderStream());
 }
 
-
 async function importReactServer() {
   let mod: typeof import("./entry-react-server");
   if (import.meta.env.DEV) {

--- a/examples/react-server/src/features/server-action/react-server.ts
+++ b/examples/react-server/src/features/server-action/react-server.ts
@@ -14,7 +14,7 @@ export async function serverActionHandler({ request }: { request: Request }) {
   const formData = await request.formData();
   const actionId = ejectActionId(formData);
   const action = await importServerAction(actionId);
-  await action(formData);
+  return await action(formData);
 }
 
 async function importServerReference(id: string): Promise<unknown> {

--- a/examples/react-server/src/features/server-action/react-server.ts
+++ b/examples/react-server/src/features/server-action/react-server.ts
@@ -1,5 +1,6 @@
 import reactServerDomWebpack from "react-server-dom-webpack/server.edge";
 import { tinyassert } from "@hiogawa/utils";
+import type { BundlerConfig, ImportManifestEntry } from "../../types";
 
 export function registerServerReference(
   action: Function,
@@ -11,15 +12,35 @@ export function registerServerReference(
 
 export async function serverActionHandler({ request }: { request: Request }) {
   const url = new URL(request.url);
-  const contentType = request.headers.get("content-type");
-  const body = contentType?.startsWith("multipart/form-data")
-    ? await request.formData()
-    : await request.text();
-  const args = await reactServerDomWebpack.decodeReply(body);
-  const actionId = url.searchParams.get("__action_id");
-  tinyassert(actionId);
-  const action = await importServerAction(actionId);
-  return await action(...args);
+  let boundAction: Function;
+  if (url.searchParams.has("__stream")) {
+    // client stream request
+    const contentType = request.headers.get("content-type");
+    const body = contentType?.startsWith("multipart/form-data")
+      ? await request.formData()
+      : await request.text();
+    const args = await reactServerDomWebpack.decodeReply(body);
+    const actionId = url.searchParams.get("__action_id");
+    tinyassert(actionId);
+    const action = await importServerAction(actionId);
+    boundAction = () => action(...args);
+  } else {
+    // progressive enhancement
+    const formData = await request.formData();
+    const decodedAction = await reactServerDomWebpack.decodeAction(
+      formData,
+      createActionBundlerConfig(),
+    );
+    boundAction = async () => {
+      const result = await decodedAction();
+      const formState = await reactServerDomWebpack.decodeFormState(
+        result,
+        formData,
+      );
+      return formState;
+    };
+  }
+  return boundAction();
 }
 
 async function importServerReference(id: string): Promise<unknown> {
@@ -37,4 +58,23 @@ async function importServerAction(id: string): Promise<Function> {
   const [file, name] = id.split("#") as [string, string];
   const mod: any = await importServerReference(file);
   return mod[name];
+}
+
+function createActionBundlerConfig(): BundlerConfig {
+  return new Proxy(
+    {},
+    {
+      get(_target, $$id, _receiver) {
+        tinyassert(typeof $$id === "string");
+        let [id, name] = $$id.split("#");
+        tinyassert(id);
+        tinyassert(name);
+        return {
+          id,
+          name,
+          chunks: [],
+        } satisfies ImportManifestEntry;
+      },
+    },
+  );
 }

--- a/examples/react-server/src/routes/_action.tsx
+++ b/examples/react-server/src/routes/_action.tsx
@@ -1,5 +1,7 @@
 "use server";
 
+import { sleep } from "@hiogawa/utils";
+
 let count = 0;
 
 export function getCounter() {
@@ -8,4 +10,19 @@ export function getCounter() {
 
 export function changeCounter(formData: FormData) {
   count += Number(formData.get("value"));
+}
+
+type CheckAnswerState = {
+  message: string;
+  count: number;
+};
+
+export async function checkAnswer(
+  prev: CheckAnswerState | null,
+  formData: FormData,
+) {
+  await sleep(500);
+  const answer = Number(formData.get("answer"));
+  const message = answer === 2 ? "Correct!" : "Wrong!";
+  return { message, count: (prev?.count ?? 0) + 1 };
 }

--- a/examples/react-server/src/routes/_client.tsx
+++ b/examples/react-server/src/routes/_client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { checkAnswer } from "./_action";
 
 export function ClientComponent() {
   const [count, setCount] = React.useState(0);
@@ -20,3 +21,40 @@ export function ClientComponent() {
     </div>
   );
 }
+
+export function UseActionStateDemo() {
+  const useActionState = (React as any).useActionState as ReactUseActionState;
+  const [data, formAction, isPending] = useActionState(checkAnswer, null);
+
+  return (
+    <form action={formAction}>
+      <h4>useActionState</h4>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.3rem" }}>
+        <div>1 + 1 = </div>
+        <input name="answer" placeholder="Answer?" required />
+        <div data-testid="action-state">
+          {isPending ? (
+            "..."
+          ) : data ? (
+            <>
+              {data.message} (tried{" "}
+              {data.count === 1 ? "once" : data.count + " times"})
+            </>
+          ) : null}
+        </div>
+      </div>
+    </form>
+  );
+}
+
+// type is copied from ReactDOM.useFormState
+// https://github.com/facebook/react/pull/28491
+type ReactUseActionState = <State, Payload>(
+  action: (state: Awaited<State>, payload: Payload) => State | Promise<State>,
+  initialState: Awaited<State>,
+  permalink?: string,
+) => [
+  state: Awaited<State>,
+  dispatch: (payload: Payload) => void,
+  isPending: boolean,
+];

--- a/examples/react-server/src/routes/_client.tsx
+++ b/examples/react-server/src/routes/_client.tsx
@@ -28,7 +28,7 @@ export function UseActionStateDemo() {
 
   return (
     <form action={formAction}>
-      <h4>useActionState</h4>
+      <h4>Hello useActionState</h4>
       <div style={{ display: "flex", alignItems: "center", gap: "0.3rem" }}>
         <div>1 + 1 = </div>
         <input name="answer" placeholder="Answer?" required />

--- a/examples/react-server/src/routes/page.tsx
+++ b/examples/react-server/src/routes/page.tsx
@@ -1,5 +1,5 @@
 import { changeCounter, getCounter } from "./_action";
-import { ClientComponent } from "./_client";
+import { ClientComponent, UseActionStateDemo } from "./_client";
 
 export default function Page() {
   return (
@@ -24,6 +24,7 @@ function ServerActionDemo() {
           +1
         </button>
       </form>
+      <UseActionStateDemo />
     </div>
   );
 }

--- a/examples/react-server/src/types/react-augment.ts
+++ b/examples/react-server/src/types/react-augment.ts
@@ -1,7 +1,6 @@
-import "react-dom/server";
-import "react-dom/client";
+import type {} from "react-dom/server";
+import type {} from "react-dom/client";
 
-// formState not typed yet
 declare module "react-dom/server" {
   interface RenderToReadableStreamOptions {
     formState: unknown;

--- a/examples/react-server/src/types/react-augment.ts
+++ b/examples/react-server/src/types/react-augment.ts
@@ -1,0 +1,15 @@
+import "react-dom/server";
+import "react-dom/client";
+
+// formState not typed yet
+declare module "react-dom/server" {
+  interface RenderToReadableStreamOptions {
+    formState: unknown;
+  }
+}
+
+declare module "react-dom/client" {
+  interface HydrationOptions {
+    formState: unknown;
+  }
+}

--- a/examples/react-server/src/types/react.d.ts
+++ b/examples/react-server/src/types/react.d.ts
@@ -23,6 +23,19 @@ declare module "react-server-dom-webpack/server.edge" {
     id: string,
     name: string,
   ): T;
+
+  export function decodeReply(body: string | FormData): Promise<unknown[]>;
+
+  export function decodeAction(
+    body: FormData,
+    bundlerConfig: import(".").BundlerConfig,
+  ): Promise<() => Promise<unknown>>;
+
+  export function decodeFormState(
+    actionResult: unknown,
+    body: FormData,
+    serverManifest?: unknown,
+  ): Promise<unknown>;
 }
 
 // https://github.com/facebook/react/blob/89021fb4ec9aa82194b0788566e736a4cedfc0e4/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
@@ -60,4 +73,6 @@ declare module "react-server-dom-webpack/client.browser" {
       callServer?: import(".").CallServerCallback;
     },
   ): Promise<T>;
+
+  export function encodeReply(v: unknown[]): Promise<string | FormData>;
 }

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -287,5 +287,31 @@ function vitePluginServerAction(): PluginOption {
     },
   );
 
-  return [transformPlugin, virtualServerReference];
+  const patchPlugin: Plugin = {
+    name: "patch-react-server-dom-webpack",
+    transform(code, id, _options) {
+      if (id.includes("react-server-dom-webpack")) {
+        // rename webpack markers in react server runtime
+        // to avoid conflict with ssr runtime which shares same globals
+        code = code.replaceAll(
+          "__webpack_require__",
+          "__vite_react_server_webpack_require__",
+        );
+        code = code.replaceAll(
+          "__webpack_chunk_load__",
+          "__vite_react_server_webpack_chunk_load__",
+        );
+
+        // make server reference async for simplicity (stale chunkCache, etc...)
+        // see TODO in https://github.com/facebook/react/blob/33a32441e991e126e5e874f831bd3afc237a3ecf/packages/react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack.js#L131-L132
+        code = code.replaceAll("if (isAsyncImport(metadata))", "if (true)");
+        code = code.replaceAll("4===a.length", "true");
+
+        return code;
+      }
+      return;
+    },
+  };
+
+  return [transformPlugin, virtualServerReference, patchPlugin];
 }

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -290,6 +290,9 @@ function vitePluginServerAction(): PluginOption {
   const patchPlugin: Plugin = {
     name: "patch-react-server-dom-webpack",
     transform(code, id, _options) {
+      if (this.environment?.name !== "react-server") {
+        return;
+      }
       if (id.includes("react-server-dom-webpack")) {
         // rename webpack markers in react server runtime
         // to avoid conflict with ssr runtime which shares same globals

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -290,10 +290,10 @@ function vitePluginServerAction(): PluginOption {
   const patchPlugin: Plugin = {
     name: "patch-react-server-dom-webpack",
     transform(code, id, _options) {
-      if (this.environment?.name !== "react-server") {
-        return;
-      }
-      if (id.includes("react-server-dom-webpack")) {
+      if (
+        this.environment?.name === "react-server" &&
+        id.includes("react-server-dom-webpack")
+      ) {
         // rename webpack markers in react server runtime
         // to avoid conflict with ssr runtime which shares same globals
         code = code.replaceAll(

--- a/examples/react-ssr-workerd/package.json
+++ b/examples/react-ssr-workerd/package.json
@@ -7,8 +7,8 @@
     "test-e2e": "playwright test"
   },
   "dependencies": {
-    "react": "18.3.0-canary-6c3b8dbfe-20240226",
-    "react-dom": "18.3.0-canary-6c3b8dbfe-20240226"
+    "react": "19.0.0-canary-4c12339ce-20240408",
+    "react-dom": "19.0.0-canary-4c12339ce-20240408"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240405.0",

--- a/examples/react-ssr/package.json
+++ b/examples/react-ssr/package.json
@@ -14,8 +14,8 @@
     "vc-release": "vercel deploy --prebuilt misc/vercel-edge --prod"
   },
   "dependencies": {
-    "react": "18.3.0-canary-6c3b8dbfe-20240226",
-    "react-dom": "18.3.0-canary-6c3b8dbfe-20240226"
+    "react": "19.0.0-canary-4c12339ce-20240408",
+    "react-dom": "19.0.0-canary-4c12339ce-20240408"
   },
   "devDependencies": {
     "@hiogawa/vite-plugin-ssr-middleware-alpha": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,14 +85,14 @@ importers:
   examples/react-server:
     dependencies:
       react:
-        specifier: 18.3.0-canary-6c3b8dbfe-20240226
-        version: 18.3.0-canary-6c3b8dbfe-20240226
+        specifier: 19.0.0-canary-4c12339ce-20240408
+        version: 19.0.0-canary-4c12339ce-20240408
       react-dom:
-        specifier: 18.3.0-canary-6c3b8dbfe-20240226
-        version: 18.3.0-canary-6c3b8dbfe-20240226(react@18.3.0-canary-6c3b8dbfe-20240226)
+        specifier: 19.0.0-canary-4c12339ce-20240408
+        version: 19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408)
       react-server-dom-webpack:
-        specifier: 18.3.0-canary-6c3b8dbfe-20240226
-        version: 18.3.0-canary-6c3b8dbfe-20240226(react-dom@18.3.0-canary-6c3b8dbfe-20240226)(react@18.3.0-canary-6c3b8dbfe-20240226)(webpack@5.91.0)
+        specifier: 19.0.0-canary-4c12339ce-20240408
+        version: 19.0.0-canary-4c12339ce-20240408(react-dom@19.0.0-canary-4c12339ce-20240408)(react@19.0.0-canary-4c12339ce-20240408)(webpack@5.91.0)
     devDependencies:
       '@hiogawa/vite-plugin-ssr-middleware-alpha':
         specifier: workspace:*
@@ -107,11 +107,11 @@ importers:
   examples/react-ssr:
     dependencies:
       react:
-        specifier: 18.3.0-canary-6c3b8dbfe-20240226
-        version: 18.3.0-canary-6c3b8dbfe-20240226
+        specifier: 19.0.0-canary-4c12339ce-20240408
+        version: 19.0.0-canary-4c12339ce-20240408
       react-dom:
-        specifier: 18.3.0-canary-6c3b8dbfe-20240226
-        version: 18.3.0-canary-6c3b8dbfe-20240226(react@18.3.0-canary-6c3b8dbfe-20240226)
+        specifier: 19.0.0-canary-4c12339ce-20240408
+        version: 19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408)
     devDependencies:
       '@hiogawa/vite-plugin-ssr-middleware-alpha':
         specifier: workspace:*
@@ -129,11 +129,11 @@ importers:
   examples/react-ssr-workerd:
     dependencies:
       react:
-        specifier: 18.3.0-canary-6c3b8dbfe-20240226
-        version: 18.3.0-canary-6c3b8dbfe-20240226
+        specifier: 19.0.0-canary-4c12339ce-20240408
+        version: 19.0.0-canary-4c12339ce-20240408
       react-dom:
-        specifier: 18.3.0-canary-6c3b8dbfe-20240226
-        version: 18.3.0-canary-6c3b8dbfe-20240226(react@18.3.0-canary-6c3b8dbfe-20240226)
+        specifier: 19.0.0-canary-4c12339ce-20240408
+        version: 19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240405.0
@@ -2689,24 +2689,32 @@ packages:
       scheduler: 0.24.0-canary-6c3b8dbfe-20240226
     dev: false
 
+  /react-dom@19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408):
+    resolution: {integrity: sha512-dMttAQ6IA63sUCCw+ZBE4QBO87PGjEcgNhNTYGHmw15ONqeUKQ8XmGEUKBOTmux7CIV9gdmKr3BGUFdGeT5ERA==}
+    peerDependencies:
+      react: 19.0.0-canary-4c12339ce-20240408
+    dependencies:
+      react: 19.0.0-canary-4c12339ce-20240408
+      scheduler: 0.25.0-canary-4c12339ce-20240408
+    dev: false
+
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-server-dom-webpack@18.3.0-canary-6c3b8dbfe-20240226(react-dom@18.3.0-canary-6c3b8dbfe-20240226)(react@18.3.0-canary-6c3b8dbfe-20240226)(webpack@5.91.0):
-    resolution: {integrity: sha512-y12/LUvpV42sWcvZulZyu5yAUfqaFSmubmstEJ+e2m3+EzcOeHd7RnfKA7jKYWGEKesc7fbibRdlSGbLbDsdRw==}
+  /react-server-dom-webpack@19.0.0-canary-4c12339ce-20240408(react-dom@19.0.0-canary-4c12339ce-20240408)(react@19.0.0-canary-4c12339ce-20240408)(webpack@5.91.0):
+    resolution: {integrity: sha512-elO6awJXbj1liRJKORVGPb/Teeu/8FDJUuinrOHdvTRAx4kXgXW4FlVr7QRuGQzi8JauT042ql0qYLfhGBD5qA==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: 18.3.0-canary-6c3b8dbfe-20240226
-      react-dom: 18.3.0-canary-6c3b8dbfe-20240226
+      react: 19.0.0-canary-4c12339ce-20240408
+      react-dom: 19.0.0-canary-4c12339ce-20240408
       webpack: ^5.59.0
     dependencies:
       acorn-loose: 8.4.0
-      loose-envify: 1.4.0
       neo-async: 2.6.2
-      react: 18.3.0-canary-6c3b8dbfe-20240226
-      react-dom: 18.3.0-canary-6c3b8dbfe-20240226(react@18.3.0-canary-6c3b8dbfe-20240226)
+      react: 19.0.0-canary-4c12339ce-20240408
+      react-dom: 19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408)
       webpack: 5.91.0(esbuild@0.20.2)
     dev: false
 
@@ -2715,6 +2723,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
+
+  /react@19.0.0-canary-4c12339ce-20240408:
+    resolution: {integrity: sha512-QdQl76CTAmYrwjxq6fZRDWw2/MHPNxkYQ1xZVir2MbK/wxK62vFAPGr2j/AXs36ADVUq+tUGx4XNmdgnfL4f1Q==}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /readdirp@3.6.0:
@@ -2803,6 +2816,10 @@ packages:
     resolution: {integrity: sha512-uRCwY7vN703Up0b4SoXgG+IXvi9Y4t8nLUoasznLNehOn8kf2E0zEGvgceFKI0Z/Jwt461EPdQNBxjuKah+jXA==}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
+
+  /scheduler@0.25.0-canary-4c12339ce-20240408:
+    resolution: {integrity: sha512-XGG/Y5q5jeJy+rKp963+nlz81H/eDEMDmwem8QFHkuufjW/IEhM9ha6PO76m9qA6Qr59HVjlTGJ6D1bH1lemeQ==}
     dev: false
 
   /schema-utils@3.3.0:


### PR DESCRIPTION
Basically we just need to port
- https://github.com/hi-ogawa/vite-plugins/pull/282

## todo

- [x] `encodeReply/decodeReply`
- [x] `decodeAction`
- [x] `decodeFormState` + ssr/hydrate `formState`
- [x] demo `useActionState`
- [x] test