### PR TITLE
chore(deps): react beta 20240430

### DIFF
--- a/examples/custom/package.json
+++ b/examples/custom/package.json
@@ -10,8 +10,8 @@
     "react-dom": "18.3.0-canary-6c3b8dbfe-20240226"
   },
   "devDependencies": {
-    "@types/react": "18.2.72",
-    "@types/react-dom": "18.2.22"
+    "@types/react": "18.3.1",
+    "@types/react-dom": "18.3.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/examples/react-server/package.json
+++ b/examples/react-server/package.json
@@ -14,9 +14,9 @@
     "cf-release": "cd misc/cloudflare-workers && wrangler deploy"
   },
   "dependencies": {
-    "react": "19.0.0-canary-4c12339ce-20240408",
-    "react-dom": "19.0.0-canary-4c12339ce-20240408",
-    "react-server-dom-webpack": "19.0.0-canary-4c12339ce-20240408"
+    "react": "19.0.0-beta-4508873393-20240430",
+    "react-dom": "19.0.0-beta-4508873393-20240430",
+    "react-server-dom-webpack": "19.0.0-beta-4508873393-20240430"
   },
   "devDependencies": {
     "@hiogawa/vite-plugin-ssr-middleware-alpha": "workspace:*",

--- a/examples/react-server/package.json
+++ b/examples/react-server/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "@hiogawa/vite-plugin-ssr-middleware-alpha": "workspace:*",
-    "@types/react": "18.2.72",
-    "@types/react-dom": "18.2.22",
+    "@types/react": "18.3.1",
+    "@types/react-dom": "18.3.0",
     "@unocss/vite": "^0.59.4",
     "happy-dom": "^14.7.1",
     "unocss": "^0.59.4"

--- a/examples/react-server/src/__snapshots__/basic.test.tsx.snap
+++ b/examples/react-server/src/__snapshots__/basic.test.tsx.snap
@@ -57,9 +57,7 @@ exports[`basic 1`] = `
             +1
           </button>
         </form>
-        <form
-          action="javascript:throw new Error('A React form was unexpectedly submitted. If you called form.submit() manually, consider using form.requestSubmit() instead. If you\\'re trying to use event.stopPropagation() in a submit event handler, consider also calling event.preventDefault().')"
-        >
+        <form>
           <h4>
             Hello useActionState
           </h4>
@@ -97,11 +95,21 @@ exports[`basic 1`] = `
         >
           unocss (client)
         </div>
-        <div
-          data-hydrated="true"
-        >
-          hydrated: 
-          true
+        <div>
+          <div
+            data-hydrated="true"
+          >
+            [hydrated: 
+            true
+            ]
+          </div>
+          <div>
+            [effect: 
+            <span>
+              2
+            </span>
+            ]
+          </div>
         </div>
         <div>
           Count: 

--- a/examples/react-server/src/routes/_client.tsx
+++ b/examples/react-server/src/routes/_client.tsx
@@ -58,7 +58,13 @@ export function UseActionStateDemo() {
 
   return (
     <form action={formAction}>
-      <h4>Hello useActionState</h4>
+      <h4
+        ref={React.useCallback((el: any) => {
+          console.log("[h4.ref]", !!el);
+        }, [])}
+      >
+        Hello useActionState
+      </h4>
       <div style={{ display: "flex", alignItems: "center", gap: "0.3rem" }}>
         <div>1 + 1 = </div>
         <input
@@ -66,6 +72,9 @@ export function UseActionStateDemo() {
           name="answer"
           placeholder="Answer?"
           required
+          ref={React.useCallback((el: any) => {
+            console.log("[input.ref]", !!el);
+          }, [])}
         />
         <div data-testid="action-state">
           {isPending ? (

--- a/examples/react-server/src/routes/_client.tsx
+++ b/examples/react-server/src/routes/_client.tsx
@@ -57,7 +57,7 @@ export function UseActionStateDemo() {
   const [data, formAction, isPending] = React.useActionState(checkAnswer, null);
 
   return (
-    <form action={formAction}>
+    <form {...useNoRequestFormReset(formAction)}>
       <h4>Hello useActionState</h4>
       <div style={{ display: "flex", alignItems: "center", gap: "0.3rem" }}>
         <div>1 + 1 = </div>
@@ -80,4 +80,24 @@ export function UseActionStateDemo() {
       </div>
     </form>
   );
+}
+
+// https://github.com/facebook/react/pull/28809
+function useNoRequestFormReset(
+  action: React.DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS["functions"],
+): Pick<JSX.IntrinsicElements["form"], "action" | "onSubmit"> {
+  const hydrated = React.useSyncExternalStore(
+    React.useCallback(() => () => {}, []),
+    () => true,
+    () => false,
+  );
+  if (hydrated) {
+    return {
+      onSubmit(e) {
+        e.preventDefault();
+        action(new FormData(e.currentTarget));
+      },
+    };
+  }
+  return { action };
 }

--- a/examples/react-server/src/routes/_client.tsx
+++ b/examples/react-server/src/routes/_client.tsx
@@ -58,13 +58,7 @@ export function UseActionStateDemo() {
 
   return (
     <form action={formAction}>
-      <h4
-        ref={React.useCallback((el: any) => {
-          console.log("[h4.ref]", !!el);
-        }, [])}
-      >
-        Hello useActionState
-      </h4>
+      <h4>Hello useActionState</h4>
       <div style={{ display: "flex", alignItems: "center", gap: "0.3rem" }}>
         <div>1 + 1 = </div>
         <input
@@ -72,9 +66,6 @@ export function UseActionStateDemo() {
           name="answer"
           placeholder="Answer?"
           required
-          ref={React.useCallback((el: any) => {
-            console.log("[input.ref]", !!el);
-          }, [])}
         />
         <div data-testid="action-state">
           {isPending ? (

--- a/examples/react-server/src/routes/_client.tsx
+++ b/examples/react-server/src/routes/_client.tsx
@@ -33,8 +33,7 @@ export function ClientComponent() {
 }
 
 export function UseActionStateDemo() {
-  const useActionState = (React as any).useActionState as ReactUseActionState;
-  const [data, formAction, isPending] = useActionState(checkAnswer, null);
+  const [data, formAction, isPending] = React.useActionState(checkAnswer, null);
 
   return (
     <form action={formAction}>
@@ -61,15 +60,3 @@ export function UseActionStateDemo() {
     </form>
   );
 }
-
-// type is copied from ReactDOM.useFormState
-// https://github.com/facebook/react/pull/28491
-type ReactUseActionState = <State, Payload>(
-  action: (state: Awaited<State>, payload: Payload) => State | Promise<State>,
-  initialState: Awaited<State>,
-  permalink?: string,
-) => [
-  state: Awaited<State>,
-  dispatch: (payload: Payload) => void,
-  isPending: boolean,
-];

--- a/examples/react-server/src/routes/_client.tsx
+++ b/examples/react-server/src/routes/_client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import "./_client.css";
+import { tinyassert } from "@hiogawa/utils";
 import React from "react";
 import { checkAnswer } from "./_action";
 import { SharedComponent } from "./_shared";
@@ -20,7 +21,10 @@ export function ClientComponent() {
       <div className="flex justify-center w-36 m-1 p-1 important:(bg-[rgb(255,220,220)])">
         unocss (client)
       </div>
-      <div data-hydrated={hydrated}>hydrated: {String(hydrated)}</div>
+      <div>
+        <div data-hydrated={hydrated}>[hydrated: {String(hydrated)}]</div>
+        <EffectCount />
+      </div>
       <div>Count: {count}</div>
       <button className="client-btn" onClick={() => setCount((v) => v - 1)}>
         -1
@@ -28,6 +32,23 @@ export function ClientComponent() {
       <button className="client-btn" onClick={() => setCount((v) => v + 1)}>
         +1
       </button>
+    </div>
+  );
+}
+
+export function EffectCount() {
+  const elRef = React.useRef<HTMLElement>(null);
+  const countRef = React.useRef(0);
+
+  React.useEffect(() => {
+    countRef.current++;
+    tinyassert(elRef.current);
+    elRef.current.textContent = String(countRef.current);
+  });
+
+  return (
+    <div>
+      [effect: <span ref={elRef}>0</span>]
     </div>
   );
 }

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -336,6 +336,7 @@ function vitePluginServerAction(): PluginOption {
         // make server reference async for simplicity (stale chunkCache, etc...)
         // see TODO in https://github.com/facebook/react/blob/33a32441e991e126e5e874f831bd3afc237a3ecf/packages/react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack.js#L131-L132
         code = code.replaceAll("if (isAsyncImport(metadata))", "if (true)");
+        code = code.replaceAll("4 === metadata.length", "true");
 
         return { code, map: null };
       }

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -336,7 +336,6 @@ function vitePluginServerAction(): PluginOption {
         // make server reference async for simplicity (stale chunkCache, etc...)
         // see TODO in https://github.com/facebook/react/blob/33a32441e991e126e5e874f831bd3afc237a3ecf/packages/react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack.js#L131-L132
         code = code.replaceAll("if (isAsyncImport(metadata))", "if (true)");
-        code = code.replaceAll("4===a.length", "true");
 
         return { code, map: null };
       }

--- a/examples/react-ssr-workerd/package.json
+++ b/examples/react-ssr-workerd/package.json
@@ -13,8 +13,8 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240405.0",
     "@hiogawa/vite-plugin-workerd": "workspace:*",
-    "@types/react": "18.2.72",
-    "@types/react-dom": "18.2.22"
+    "@types/react": "18.3.1",
+    "@types/react-dom": "18.3.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/examples/react-ssr-workerd/package.json
+++ b/examples/react-ssr-workerd/package.json
@@ -7,8 +7,8 @@
     "test-e2e": "playwright test"
   },
   "dependencies": {
-    "react": "19.0.0-canary-4c12339ce-20240408",
-    "react-dom": "19.0.0-canary-4c12339ce-20240408"
+    "react": "19.0.0-beta-4508873393-20240430",
+    "react-dom": "19.0.0-beta-4508873393-20240430"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240405.0",

--- a/examples/react-ssr/package.json
+++ b/examples/react-ssr/package.json
@@ -20,8 +20,8 @@
   "devDependencies": {
     "@hiogawa/vite-plugin-ssr-middleware-alpha": "workspace:*",
     "@hiogawa/vite-plugin-workerd": "workspace:*",
-    "@types/react": "18.2.72",
-    "@types/react-dom": "18.2.22"
+    "@types/react": "18.3.1",
+    "@types/react-dom": "18.3.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/examples/react-ssr/package.json
+++ b/examples/react-ssr/package.json
@@ -14,8 +14,8 @@
     "vc-release": "vercel deploy --prebuilt misc/vercel-edge --prod"
   },
   "dependencies": {
-    "react": "19.0.0-canary-4c12339ce-20240408",
-    "react-dom": "19.0.0-canary-4c12339ce-20240408"
+    "react": "19.0.0-beta-4508873393-20240430",
+    "react-dom": "19.0.0-beta-4508873393-20240430"
   },
   "devDependencies": {
     "@hiogawa/vite-plugin-ssr-middleware-alpha": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,11 +82,11 @@ importers:
         version: 18.3.0-canary-6c3b8dbfe-20240226(react@18.3.0-canary-6c3b8dbfe-20240226)
     devDependencies:
       '@types/react':
-        specifier: 18.2.72
-        version: 18.2.72
+        specifier: 18.3.1
+        version: 18.3.1
       '@types/react-dom':
-        specifier: 18.2.22
-        version: 18.2.22
+        specifier: 18.3.0
+        version: 18.3.0
 
   examples/react-server:
     dependencies:
@@ -104,11 +104,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ssr-middleware
       '@types/react':
-        specifier: 18.2.72
-        version: 18.2.72
+        specifier: 18.3.1
+        version: 18.3.1
       '@types/react-dom':
-        specifier: 18.2.22
-        version: 18.2.22
+        specifier: 18.3.0
+        version: 18.3.0
       '@unocss/vite':
         specifier: ^0.59.4
         version: 0.59.4(vite@6.0.0-alpha.7)
@@ -135,11 +135,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workerd
       '@types/react':
-        specifier: 18.2.72
-        version: 18.2.72
+        specifier: 18.3.1
+        version: 18.3.1
       '@types/react-dom':
-        specifier: 18.2.22
-        version: 18.2.22
+        specifier: 18.3.0
+        version: 18.3.0
 
   examples/react-ssr-workerd:
     dependencies:
@@ -157,11 +157,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workerd
       '@types/react':
-        specifier: 18.2.72
-        version: 18.2.72
+        specifier: 18.3.1
+        version: 18.3.1
       '@types/react-dom':
-        specifier: 18.2.22
-        version: 18.2.22
+        specifier: 18.3.0
+        version: 18.3.0
 
   examples/vue-ssr:
     dependencies:
@@ -1650,14 +1650,14 @@ packages:
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
     dev: true
 
-  /@types/react-dom@18.2.22:
-    resolution: {integrity: sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==}
+  /@types/react-dom@18.3.0:
+    resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
     dependencies:
-      '@types/react': 18.2.72
+      '@types/react': 18.3.1
     dev: true
 
-  /@types/react@18.2.72:
-    resolution: {integrity: sha512-/e7GWxGzXQF7OJAua7UAYqYi/4VpXEfbGtmYQcAQwP3SjjjAXfybTf/JK5S+SaetB/ChXl8Y2g1hCsj7jDXxcg==}
+  /@types/react@18.3.1:
+    resolution: {integrity: sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==}
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,14 +91,14 @@ importers:
   examples/react-server:
     dependencies:
       react:
-        specifier: 19.0.0-canary-4c12339ce-20240408
-        version: 19.0.0-canary-4c12339ce-20240408
+        specifier: 19.0.0-beta-4508873393-20240430
+        version: 19.0.0-beta-4508873393-20240430
       react-dom:
-        specifier: 19.0.0-canary-4c12339ce-20240408
-        version: 19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408)
+        specifier: 19.0.0-beta-4508873393-20240430
+        version: 19.0.0-beta-4508873393-20240430(react@19.0.0-beta-4508873393-20240430)
       react-server-dom-webpack:
-        specifier: 19.0.0-canary-4c12339ce-20240408
-        version: 19.0.0-canary-4c12339ce-20240408(react-dom@19.0.0-canary-4c12339ce-20240408)(react@19.0.0-canary-4c12339ce-20240408)(webpack@5.91.0)
+        specifier: 19.0.0-beta-4508873393-20240430
+        version: 19.0.0-beta-4508873393-20240430(react-dom@19.0.0-beta-4508873393-20240430)(react@19.0.0-beta-4508873393-20240430)(webpack@5.91.0)
     devDependencies:
       '@hiogawa/vite-plugin-ssr-middleware-alpha':
         specifier: workspace:*
@@ -122,11 +122,11 @@ importers:
   examples/react-ssr:
     dependencies:
       react:
-        specifier: 19.0.0-canary-4c12339ce-20240408
-        version: 19.0.0-canary-4c12339ce-20240408
+        specifier: 19.0.0-beta-4508873393-20240430
+        version: 19.0.0-beta-4508873393-20240430
       react-dom:
-        specifier: 19.0.0-canary-4c12339ce-20240408
-        version: 19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408)
+        specifier: 19.0.0-beta-4508873393-20240430
+        version: 19.0.0-beta-4508873393-20240430(react@19.0.0-beta-4508873393-20240430)
     devDependencies:
       '@hiogawa/vite-plugin-ssr-middleware-alpha':
         specifier: workspace:*
@@ -144,11 +144,11 @@ importers:
   examples/react-ssr-workerd:
     dependencies:
       react:
-        specifier: 19.0.0-canary-4c12339ce-20240408
-        version: 19.0.0-canary-4c12339ce-20240408
+        specifier: 19.0.0-beta-4508873393-20240430
+        version: 19.0.0-beta-4508873393-20240430
       react-dom:
-        specifier: 19.0.0-canary-4c12339ce-20240408
-        version: 19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408)
+        specifier: 19.0.0-beta-4508873393-20240430
+        version: 19.0.0-beta-4508873393-20240430(react@19.0.0-beta-4508873393-20240430)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240405.0
@@ -3498,13 +3498,13 @@ packages:
       scheduler: 0.24.0-canary-6c3b8dbfe-20240226
     dev: false
 
-  /react-dom@19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408):
-    resolution: {integrity: sha512-dMttAQ6IA63sUCCw+ZBE4QBO87PGjEcgNhNTYGHmw15ONqeUKQ8XmGEUKBOTmux7CIV9gdmKr3BGUFdGeT5ERA==}
+  /react-dom@19.0.0-beta-4508873393-20240430(react@19.0.0-beta-4508873393-20240430):
+    resolution: {integrity: sha512-/j97ai1qF3c6O3XV0nVzzExPV/0U2v8M75Sq6ThXYxePCi33kAnm+xRsCDpZOZOrIjz6nurLU/FzzPZIzXVvKQ==}
     peerDependencies:
-      react: 19.0.0-canary-4c12339ce-20240408
+      react: 19.0.0-beta-4508873393-20240430
     dependencies:
-      react: 19.0.0-canary-4c12339ce-20240408
-      scheduler: 0.25.0-canary-4c12339ce-20240408
+      react: 19.0.0-beta-4508873393-20240430
+      scheduler: 0.25.0-beta-4508873393-20240430
     dev: false
 
   /react-is@18.2.0:
@@ -3516,18 +3516,18 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-server-dom-webpack@19.0.0-canary-4c12339ce-20240408(react-dom@19.0.0-canary-4c12339ce-20240408)(react@19.0.0-canary-4c12339ce-20240408)(webpack@5.91.0):
-    resolution: {integrity: sha512-elO6awJXbj1liRJKORVGPb/Teeu/8FDJUuinrOHdvTRAx4kXgXW4FlVr7QRuGQzi8JauT042ql0qYLfhGBD5qA==}
+  /react-server-dom-webpack@19.0.0-beta-4508873393-20240430(react-dom@19.0.0-beta-4508873393-20240430)(react@19.0.0-beta-4508873393-20240430)(webpack@5.91.0):
+    resolution: {integrity: sha512-/rRIMqNoeReqyioWwfLyqu/qUfZ39YLXOfkhLrXOStzG2g7Q2a5DoLD0eZOcCIpvpWg+/QRw1xOGZLm75mK+Aw==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: 19.0.0-canary-4c12339ce-20240408
-      react-dom: 19.0.0-canary-4c12339ce-20240408
+      react: 19.0.0-beta-4508873393-20240430
+      react-dom: 19.0.0-beta-4508873393-20240430
       webpack: ^5.59.0
     dependencies:
       acorn-loose: 8.4.0
       neo-async: 2.6.2
-      react: 19.0.0-canary-4c12339ce-20240408
-      react-dom: 19.0.0-canary-4c12339ce-20240408(react@19.0.0-canary-4c12339ce-20240408)
+      react: 19.0.0-beta-4508873393-20240430
+      react-dom: 19.0.0-beta-4508873393-20240430(react@19.0.0-beta-4508873393-20240430)
       webpack: 5.91.0(esbuild@0.20.2)
     dev: false
 
@@ -3538,8 +3538,8 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
-  /react@19.0.0-canary-4c12339ce-20240408:
-    resolution: {integrity: sha512-QdQl76CTAmYrwjxq6fZRDWw2/MHPNxkYQ1xZVir2MbK/wxK62vFAPGr2j/AXs36ADVUq+tUGx4XNmdgnfL4f1Q==}
+  /react@19.0.0-beta-4508873393-20240430:
+    resolution: {integrity: sha512-//89udV7fhVq5pEzpNH7vlpmS5D4wDbPn0oif+G7vwDsuSks5yJGdqrE1uzn2CyFNL73FjV3/R3Pjyaxs+xnvg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -3631,8 +3631,8 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
-  /scheduler@0.25.0-canary-4c12339ce-20240408:
-    resolution: {integrity: sha512-XGG/Y5q5jeJy+rKp963+nlz81H/eDEMDmwem8QFHkuufjW/IEhM9ha6PO76m9qA6Qr59HVjlTGJ6D1bH1lemeQ==}
+  /scheduler@0.25.0-beta-4508873393-20240430:
+    resolution: {integrity: sha512-gk9vDoDOjTys0DpLgFll+hYk5gLhLnTipi81Pl+XSRtWkQnqQdjxLO2RF726t0g0jQ5tvwjLfBCgsvusgB6Luw==}
     dev: false
 
   /schema-utils@3.3.0:


### PR DESCRIPTION
Let's wait for
- https://github.com/facebook/react/pull/28901
- https://github.com/facebook/react/pull/28921 

---

It looks like `input` is cleared now after `formAction`, which wasn't the case before.

---

This is actually mentioned in the changelog https://react.dev/blog/2024/04/25/react-19

> Forms: `<form>` elements now support passing functions to the action and formAction props. Passing functions to the action props use Actions by default and reset the form automatically after submission.

> When a `<form>` Action succeeds, React will automatically reset the form for uncontrolled components. If you need to reset the `<form>` manually, you can call the new requestFormReset React DOM API.

what's `requestFormReset`?

See also
- https://github.com/facebook/react/pull/28809

So, it's not possible to _not_ `requestFormRequest` for uncontrolled input except making it controlled?

