### PR TITLE
feat: `sharedDuringBuild` unocss plugin

### DIFF
--- a/examples/react-server/README.md
+++ b/examples/react-server/README.md
@@ -35,4 +35,5 @@ pnpm cf-release
 - [x] css
   - [x] client
   - [x] server
+  - [x] unocss
   - [ ] code split

--- a/examples/react-server/package.json
+++ b/examples/react-server/package.json
@@ -22,7 +22,9 @@
     "@hiogawa/vite-plugin-ssr-middleware-alpha": "workspace:*",
     "@types/react": "18.2.72",
     "@types/react-dom": "18.2.22",
-    "happy-dom": "^14.7.1"
+    "@unocss/vite": "^0.59.4",
+    "happy-dom": "^14.7.1",
+    "unocss": "^0.59.4"
   },
   "volta": {
     "extends": "../../package.json"

--- a/examples/react-server/src/__snapshots__/basic.test.tsx.snap
+++ b/examples/react-server/src/__snapshots__/basic.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`basic 1`] = `
         )
       </div>
       <div
+        class="flex justify-center w-36 m-1 p-1 bg-[rgb(220,220,255)]"
+      >
+        unocss (server)
+      </div>
+      <div
         data-testid="server-action"
       >
         <h4>
@@ -86,6 +91,11 @@ exports[`basic 1`] = `
           Shared Component (
           client
           )
+        </div>
+        <div
+          class="flex justify-center w-36 m-1 p-1 bg-[rgb(255,220,220)]"
+        >
+          unocss (client)
         </div>
         <div
           data-hydrated="true"

--- a/examples/react-server/src/entry-client.tsx
+++ b/examples/react-server/src/entry-client.tsx
@@ -1,3 +1,4 @@
+import "virtual:unocss.css";
 import React from "react";
 import reactDomClient from "react-dom/client";
 import type { StreamData } from "./entry-react-server";

--- a/examples/react-server/src/features/style/plugin.ts
+++ b/examples/react-server/src/features/style/plugin.ts
@@ -24,8 +24,8 @@ export function vitePluginServerCss({
         server.middlewares.use((req, _res, next) => {
           if (req.url === `/@id/__x00__${VIRTUAL_SSR_CSS}`) {
             const env = $__global.server.environments["client"];
-            invalidateModuleById(env, `\0${VIRTUAL_SSR_CSS}?direct`);
-            invalidateModuleById(env, `\0${VIRTUAL_COPY_SERVER_CSS}`);
+            invalidateModule(env, `\0${VIRTUAL_SSR_CSS}?direct`);
+            invalidateModule(env, `\0${VIRTUAL_COPY_SERVER_CSS}`);
           }
           next();
         });
@@ -100,7 +100,7 @@ export function vitePluginServerCss({
   ];
 }
 
-export function invalidateModuleById(server: DevEnvironment, id: string) {
+export function invalidateModule(server: DevEnvironment, id: string) {
   const mod = server.moduleGraph.getModuleById(id);
   if (mod) {
     server.moduleGraph.invalidateModule(mod);

--- a/examples/react-server/src/features/style/plugin.ts
+++ b/examples/react-server/src/features/style/plugin.ts
@@ -24,8 +24,8 @@ export function vitePluginServerCss({
         server.middlewares.use((req, _res, next) => {
           if (req.url === `/@id/__x00__${VIRTUAL_SSR_CSS}`) {
             const env = $__global.server.environments["client"];
-            invalidateModule(env, `\0${VIRTUAL_SSR_CSS}?direct`);
-            invalidateModule(env, `\0${VIRTUAL_COPY_SERVER_CSS}`);
+            invalidateModuleById(env, `\0${VIRTUAL_SSR_CSS}?direct`);
+            invalidateModuleById(env, `\0${VIRTUAL_COPY_SERVER_CSS}`);
           }
           next();
         });
@@ -60,8 +60,9 @@ export function vitePluginServerCss({
         },
       },
     },
-    createVirtualPlugin(VIRTUAL_SSR_CSS.slice(8) + "?direct", async () => {
+    createVirtualPlugin(VIRTUAL_SSR_CSS.slice(8), async (id) => {
       tinyassert($__global.server);
+      tinyassert(id.includes("?direct"));
       return collectStyle($__global.server.environments["client"], [
         ENTRY_CLIENT_BOOTSTRAP,
         // TODO: split css per-route?
@@ -99,11 +100,12 @@ export function vitePluginServerCss({
   ];
 }
 
-function invalidateModule(server: DevEnvironment, id: string) {
+export function invalidateModuleById(server: DevEnvironment, id: string) {
   const mod = server.moduleGraph.getModuleById(id);
   if (mod) {
     server.moduleGraph.invalidateModule(mod);
   }
+  return mod;
 }
 
 async function collectStyle(server: DevEnvironment, entries: string[]) {

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -1,6 +1,6 @@
 import { debounce, objectHas, tinyassert } from "@hiogawa/utils";
 import vitePluginUnocss, { type UnocssVitePluginAPI } from "@unocss/vite";
-import type { PluginOption, ViteDevServer } from "vite";
+import { DevEnvironment, type Plugin } from "vite";
 import { invalidateModuleById } from "../style/plugin";
 import { createVirtualPlugin } from "../utils/plugin";
 
@@ -8,103 +8,102 @@ import { createVirtualPlugin } from "../utils/plugin";
 // https://github.com/unocss/unocss/tree/47eafba27619ed26579df60fe3fdeb6122b5093c/packages/vite/src/modes/global
 // https://github.com/tailwindlabs/tailwindcss/blob/719c0d488378002ff752e8dc7199c843930bb296/packages/%40tailwindcss-vite/src/index.ts
 
-export function vitePluginUnocssReactServer(): PluginOption {
+export function vitePluginUnocssReactServer(): Plugin {
   const ctx = getUnocssContext();
 
-  function onUpdate(server: ViteDevServer) {
-    const mod = invalidateModuleById(
-      server.environments.client,
-      "\0virtual:unocss.css",
-    );
-    if (mod) {
-      server.environments.client.hot.send({
-        type: "update",
-        updates: [
-          {
-            type: "js-update",
-            path: "/@id/__x00__virtual:unocss.css",
-            acceptedPath: "/@id/__x00__virtual:unocss.css",
-            timestamp: Date.now(),
-          },
-        ],
+  return {
+    name: vitePluginUnocssReactServer.name + ":create",
+    sharedDuringBuild: true,
+    create(environment) {
+      const plugins: Plugin[] = [];
+
+      // (dev, build) [all envs]
+      // extract tokens by intercepting transform
+      plugins.push({
+        name: vitePluginUnocssReactServer.name + ":extract",
+        transform(code, id) {
+          if (ctx.filter(code, id)) {
+            ctx.extract(code, id);
+          }
+        },
       });
-    }
-  }
 
-  return [
-    {
-      name: vitePluginUnocssReactServer.name,
-      sharedDuringBuild: true,
-
-      // TODO: move these two `create` version below
-
-      // (dev, build) extract tokens by intercepting transform
-      transform(code, id, _options) {
-        if (ctx.filter(code, id)) {
-          ctx.extract(code, id);
+      // (dev) [client]
+      // HMR
+      if (environment.mode === "dev" && environment.name === "client") {
+        tinyassert(environment instanceof DevEnvironment);
+        const devEnv = environment;
+        function hotUpdate() {
+          const mod = invalidateModuleById(devEnv, "\0virtual:unocss.css");
+          if (mod) {
+            devEnv.hot.send({
+              type: "update",
+              updates: [
+                {
+                  type: "js-update",
+                  path: "/@id/__x00__virtual:unocss.css",
+                  acceptedPath: "/@id/__x00__virtual:unocss.css",
+                  timestamp: Date.now(),
+                },
+              ],
+            });
+          }
         }
-      },
-
-      // (dev) hmr
-      async configureServer(server) {
-        const debounced = debounce(() => onUpdate(server), 50);
+        const debounced = debounce(() => hotUpdate(), 50);
         ctx.onInvalidate(debounced);
         ctx.onReload(debounced);
-      },
-    },
-    {
-      name: vitePluginUnocssReactServer.name + ":create",
-      sharedDuringBuild: true,
+      }
 
-      // [feedback] `create` plugin cannot have `transform` together?
-      create(environment) {
-        // (dev) virtual module directly transformed
-        if (environment.mode === "dev") {
-          return [
-            createVirtualPlugin("unocss.css", async () => {
-              await ctx.flushTasks();
-              const result = await ctx.uno.generate(ctx.tokens);
-              return result.css;
-            }),
-          ];
-        }
+      // (dev) [all envs]
+      // transform virtual module directly
+      if (environment.mode === "dev") {
+        plugins.push(
+          createVirtualPlugin("unocss.css", async () => {
+            await ctx.flushTasks();
+            const result = await ctx.uno.generate(ctx.tokens);
+            return result.css;
+          }),
+        );
+      }
 
-        // (build) virtual module transformed during renderChunk
-        if (environment.mode === "build") {
-          const plugins = environment.config.plugins.filter(
-            (p) => p.name === "vite:css" || p.name === "vite:css-post",
-          );
-          return [
-            createVirtualPlugin("unocss.css", () => "/*** todo: unocss ***/"),
-            {
-              name: vitePluginUnocssReactServer.name + ":render",
-              async renderChunk(_code, chunk, _options) {
-                if (chunk.moduleIds.includes("\0virtual:unocss.css")) {
-                  await ctx.flushTasks();
-                  let { css } = await ctx.uno.generate(ctx.tokens);
-                  // [feedback] environment in renderChunk context?
-                  const pluginCtx = { ...this, environment };
-                  for (const plugin of plugins) {
-                    tinyassert(typeof plugin.transform === "function");
-                    const result = await plugin.transform.apply(
-                      pluginCtx as any,
-                      [css, "\0virtual:unocss.css"],
-                    );
-                    tinyassert(
-                      objectHas(result, "code") &&
-                        typeof result.code === "string",
-                    );
-                    css = result.code;
-                  }
+      // (build) [all envs]
+      // transform virtual module during renderChunk
+      if (environment.mode === "build") {
+        const cssPlugins = environment.config.plugins.filter(
+          (p) => p.name === "vite:css" || p.name === "vite:css-post",
+        );
+
+        plugins.push(
+          createVirtualPlugin("unocss.css", () => "/*** todo: unocss ***/"),
+          {
+            name: vitePluginUnocssReactServer.name + ":render",
+            async renderChunk(_code, chunk, _options) {
+              if (chunk.moduleIds.includes("\0virtual:unocss.css")) {
+                await ctx.flushTasks();
+                let { css } = await ctx.uno.generate(ctx.tokens);
+                // [feedback] environment in renderChunk context?
+                const pluginCtx = { ...this, environment };
+                for (const plugin of cssPlugins) {
+                  tinyassert(typeof plugin.transform === "function");
+                  const result = await plugin.transform.apply(
+                    pluginCtx as any,
+                    [css, "\0virtual:unocss.css"],
+                  );
+                  tinyassert(
+                    objectHas(result, "code") &&
+                      typeof result.code === "string",
+                  );
+                  css = result.code;
                 }
-              },
+              }
             },
-          ];
-        }
-        return;
-      },
+          },
+        );
+      }
+
+      return plugins;
     },
-  ];
+  };
 }
 
 // create DIY plugin by grabbing unocss instance

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -1,0 +1,68 @@
+import { debounce, tinyassert } from "@hiogawa/utils";
+import vitePluginUnocss, { type UnocssVitePluginAPI } from "@unocss/vite";
+import type { PluginOption, ViteDevServer } from "vite";
+import { invalidateModuleById } from "../style/plugin";
+import { createVirtualPlugin } from "../utils/plugin";
+
+// cf.
+// https://github.com/unocss/unocss/tree/47eafba27619ed26579df60fe3fdeb6122b5093c/packages/vite/src/modes/global
+// https://github.com/tailwindlabs/tailwindcss/blob/719c0d488378002ff752e8dc7199c843930bb296/packages/%40tailwindcss-vite/src/index.ts
+
+export function vitePluginUnocssReactServer(): PluginOption {
+  const ctx = getUnocssContext();
+
+  function onUpdate(server: ViteDevServer) {
+    console.log("[unocss:onUpdate]");
+    const mod = invalidateModuleById(
+      server.environments.client,
+      "\0virtual:unocss.css",
+    );
+    if (mod) {
+      server.environments.client.hot.send({
+        type: "update",
+        updates: [
+          {
+            type: "js-update",
+            path: "/@id/__x00__virtual:unocss.css",
+            acceptedPath: "/@id/__x00__virtual:unocss.css",
+            timestamp: Date.now(),
+          },
+        ],
+      });
+    }
+  }
+
+  return [
+    {
+      name: vitePluginUnocssReactServer.name,
+      transform(code, id, _options) {
+        if (ctx.filter(code, id)) {
+          ctx.extract(code, id);
+        }
+      },
+      async configureServer(server) {
+        await ctx.uno.generate([], { preflights: true });
+        const debounced = debounce(() => onUpdate(server), 50);
+        ctx.onInvalidate(debounced);
+        ctx.onReload(debounced);
+      },
+      // TODO
+      sharedDuringBuild: true,
+      renderChunk() {},
+    },
+    createVirtualPlugin("unocss.css", async (id) => {
+      console.log("[virtual:unocss.css]", { id });
+      await ctx.flushTasks();
+      const result = await ctx.uno.generate(ctx.tokens);
+      return result.css;
+    }),
+  ];
+}
+
+// create DIY plugin by grabbing unocss instance
+function getUnocssContext() {
+  const plugins = vitePluginUnocss();
+  const plugin = plugins.find((p) => p.name === "unocss:api");
+  tinyassert(plugin);
+  return (plugin.api as UnocssVitePluginAPI).getContext();
+}

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -36,14 +36,14 @@ export function vitePluginUnocssReactServer(): PluginOption {
       name: vitePluginUnocssReactServer.name,
       sharedDuringBuild: true,
 
-      // extract tokens by intercepting transform
+      // (dev, build) extract tokens by intercepting transform
       transform(code, id, _options) {
         if (ctx.filter(code, id)) {
           ctx.extract(code, id);
         }
       },
 
-      // hmr
+      // (dev) hmr
       async configureServer(server) {
         const debounced = debounce(() => onUpdate(server), 50);
         ctx.onInvalidate(debounced);
@@ -57,7 +57,7 @@ export function vitePluginUnocssReactServer(): PluginOption {
       // [feedback] `create` plugin cannot have `transform` together?
       create(environment) {
         if (environment.mode === "dev") {
-          // virtual module directly transformed
+          // (dev) virtual module directly transformed
           return [
             createVirtualPlugin("unocss.css", async () => {
               await ctx.flushTasks();
@@ -67,7 +67,7 @@ export function vitePluginUnocssReactServer(): PluginOption {
           ];
         }
         if (environment.mode === "build") {
-          // virtual module processed during renderChunk
+          // (build) virtual module processed during renderChunk
           let found = false;
           return [
             createVirtualPlugin("unocss.css", async () => {

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -28,8 +28,10 @@ export function vitePluginSharedUnocss(): Plugin {
         },
       });
 
-      // Following plugins are naturally applied to environments which imports "virtual:unocss.css".
-      // So, even though we only need to handle `environment.name === "client"` case, such restriction is not necessary.
+      // Following plugins are naturally applied to environments
+      // which imports "virtual:unocss.css".
+      // So, even though we only need to handle "client" environment case,
+      // such artificial restriction is not necessary.
 
       // [dev]
       if (environment.mode === "dev") {

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -1,7 +1,7 @@
 import { debounce, objectHas, tinyassert } from "@hiogawa/utils";
 import vitePluginUnocss, { type UnocssVitePluginAPI } from "@unocss/vite";
 import { DevEnvironment, type Plugin } from "vite";
-import { invalidateModuleById } from "../style/plugin";
+import { invalidateModule } from "../style/plugin";
 import { createVirtualPlugin } from "../utils/plugin";
 
 // cf.
@@ -47,7 +47,7 @@ export function vitePluginSharedUnocss(): Plugin {
         // HMR
         function hotUpdate() {
           tinyassert(environment instanceof DevEnvironment);
-          const mod = invalidateModuleById(environment, "\0virtual:unocss.css");
+          const mod = invalidateModule(environment, "\0virtual:unocss.css");
           if (mod) {
             environment.hot.send({
               type: "update",

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -28,8 +28,8 @@ export function vitePluginSharedUnocss(): Plugin {
         },
       });
 
-      // Following plugins are naturally applied to environments
-      // which imports "virtual:unocss.css".
+      // Following plugins are naturally applied to the environments
+      // which import "virtual:unocss.css".
       // So, even though we only need to handle "client" environment case,
       // such artificial restriction is not necessary.
 

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -8,6 +8,11 @@ import { createVirtualPlugin } from "../utils/plugin";
 // https://github.com/unocss/unocss/tree/47eafba27619ed26579df60fe3fdeb6122b5093c/packages/vite/src/modes/global
 // https://github.com/tailwindlabs/tailwindcss/blob/719c0d488378002ff752e8dc7199c843930bb296/packages/%40tailwindcss-vite/src/index.ts
 
+// TODO:
+// - content hash not changing?
+// - unocss transform plugin?
+// - non global mode?
+
 export function vitePluginSharedUnocss(): Plugin {
   const ctx = getUnocssContext();
 

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -12,6 +12,7 @@ import { createVirtualPlugin } from "../utils/plugin";
 // - content hash not changing?
 // - unocss transform plugin?
 // - non global mode?
+// - source map?
 
 export function vitePluginSharedUnocss(): Plugin {
   const ctx = getUnocssContext();

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -40,7 +40,6 @@ export function vitePluginUnocssReactServer(): PluginOption {
         }
       },
       async configureServer(server) {
-        await ctx.uno.generate([], { preflights: true });
         const debounced = debounce(() => onUpdate(server), 50);
         ctx.onInvalidate(debounced);
         ctx.onReload(debounced);

--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -12,7 +12,6 @@ export function vitePluginUnocssReactServer(): PluginOption {
   const ctx = getUnocssContext();
 
   function onUpdate(server: ViteDevServer) {
-    console.log("[unocss:onUpdate]");
     const mod = invalidateModuleById(
       server.environments.client,
       "\0virtual:unocss.css",
@@ -50,8 +49,7 @@ export function vitePluginUnocssReactServer(): PluginOption {
       sharedDuringBuild: true,
       renderChunk() {},
     },
-    createVirtualPlugin("unocss.css", async (id) => {
-      console.log("[virtual:unocss.css]", { id });
+    createVirtualPlugin("unocss.css", async () => {
       await ctx.flushTasks();
       const result = await ctx.uno.generate(ctx.tokens);
       return result.css;

--- a/examples/react-server/src/features/utils/plugin.ts
+++ b/examples/react-server/src/features/utils/plugin.ts
@@ -41,10 +41,13 @@ export function createVirtualPlugin(name: string, load: Plugin["load"]) {
   return {
     name: `virtual-${name}`,
     resolveId(source, _importer, _options) {
-      return source === name ? "\0" + name : undefined;
+      if (source === name || source.startsWith(`${name}?`)) {
+        return `\0${source}`;
+      }
+      return;
     },
     load(id, options) {
-      if (id === "\0" + name) {
+      if (id === `\0${name}` || id.startsWith(`\0${name}?`)) {
         return (load as any).apply(this, [id, options]);
       }
     },

--- a/examples/react-server/src/routes/_client.tsx
+++ b/examples/react-server/src/routes/_client.tsx
@@ -17,7 +17,7 @@ export function ClientComponent() {
     <div data-testid="client-component">
       <h4>Hello Client Component</h4>
       <SharedComponent message="client" />
-      <div className="flex justify-center w-36 bg-[rgb(255,220,220)] m-1 p-1">
+      <div className="flex justify-center w-36 m-1 p-1 bg-[rgb(255,220,220)]">
         unocss (client)
       </div>
       <div data-hydrated={hydrated}>hydrated: {String(hydrated)}</div>

--- a/examples/react-server/src/routes/_client.tsx
+++ b/examples/react-server/src/routes/_client.tsx
@@ -17,6 +17,9 @@ export function ClientComponent() {
     <div data-testid="client-component">
       <h4>Hello Client Component</h4>
       <SharedComponent message="client" />
+      <div className="flex justify-center w-36 bg-[rgb(255,220,220)] m-1 p-1">
+        unocss (client)
+      </div>
       <div data-hydrated={hydrated}>hydrated: {String(hydrated)}</div>
       <div>Count: {count}</div>
       <button className="client-btn" onClick={() => setCount((v) => v - 1)}>

--- a/examples/react-server/src/routes/page.tsx
+++ b/examples/react-server/src/routes/page.tsx
@@ -26,7 +26,7 @@ async function Page() {
     <div>
       <h4>Hello Server Component</h4>
       <SharedComponent message="server" />
-      <div className="flex justify-center w-36 bg-[rgb(220,220,255)] m-1 p-1">
+      <div className="flex justify-center w-36 m-1 p-1 bg-[rgb(220,220,255)]">
         unocss (server)
       </div>
       <ServerActionDemo />

--- a/examples/react-server/src/routes/page.tsx
+++ b/examples/react-server/src/routes/page.tsx
@@ -26,6 +26,9 @@ async function Page() {
     <div>
       <h4>Hello Server Component</h4>
       <SharedComponent message="server" />
+      <div className="flex justify-center w-36 bg-[rgb(220,220,255)] m-1 p-1">
+        unocss (server)
+      </div>
       <ServerActionDemo />
       <ClientComponent />
     </div>

--- a/examples/react-server/uno.config.ts
+++ b/examples/react-server/uno.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig, presetUno } from "unocss";
+
+export default defineConfig({
+  presets: [presetUno()],
+});

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -17,6 +17,7 @@ import {
 } from "./src/features/bootstrap/plugin";
 import { vitePluginServerCss } from "./src/features/style/plugin";
 import { vitePluginTestReactServerStream } from "./src/features/test/plugin";
+import { vitePluginUnocssReactServer } from "./src/features/unocss/plugin";
 import {
   collectFiles,
   createVirtualPlugin,
@@ -33,6 +34,7 @@ export default defineConfig((_env) => ({
   plugins: [
     !process.env["VITEST"] && react(),
     vitePluginReactServer(),
+    vitePluginUnocssReactServer(),
     vitePluginLogger(),
     vitePluginSsrMiddleware({
       entry: process.env["SERVER_ENTRY"] ?? "/src/adapters/node",

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -17,7 +17,7 @@ import {
 } from "./src/features/bootstrap/plugin";
 import { vitePluginServerCss } from "./src/features/style/plugin";
 import { vitePluginTestReactServerStream } from "./src/features/test/plugin";
-import { vitePluginUnocssReactServer } from "./src/features/unocss/plugin";
+import { vitePluginSharedUnocss } from "./src/features/unocss/plugin";
 import {
   collectFiles,
   createVirtualPlugin,
@@ -34,7 +34,7 @@ export default defineConfig((_env) => ({
   plugins: [
     !process.env["VITEST"] && react(),
     vitePluginReactServer(),
-    vitePluginUnocssReactServer(),
+    vitePluginSharedUnocss(),
     vitePluginLogger(),
     vitePluginSsrMiddleware({
       entry: process.env["SERVER_ENTRY"] ?? "/src/adapters/node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,9 +109,15 @@ importers:
       '@types/react-dom':
         specifier: 18.2.22
         version: 18.2.22
+      '@unocss/vite':
+        specifier: ^0.59.4
+        version: 0.59.4(vite@6.0.0-alpha.6)
       happy-dom:
         specifier: ^14.7.1
         version: 14.7.1
+      unocss:
+        specifier: ^0.59.4
+        version: 0.59.4(postcss@8.4.38)(vite@6.0.0-alpha.6)
 
   examples/react-ssr:
     dependencies:
@@ -239,6 +245,17 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
+  /@antfu/install-pkg@0.1.1:
+    resolution: {integrity: sha512-LyB/8+bSfa0DFGC06zpCEfs89/XoWZwws5ygEa5D+Xsm3OfI+aXQ86VgVG7Acyef+rSZ5HE7J8rrxzrQeM3PjQ==}
+    dependencies:
+      execa: 5.1.1
+      find-up: 5.0.0
+    dev: true
+
+  /@antfu/utils@0.7.7:
+    resolution: {integrity: sha512-gFPqTG7otEJ8uP6wrhDv6mqwGWYZKNvAcCq6u9hOj0c+IKCEsY4L1oC9trPq2SaWIzAfHvqfBDxF591JkMf+kg==}
+    dev: true
+
   /@babel/code-frame@7.24.2:
     resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
     engines: {node: '>=6.9.0'}
@@ -275,6 +292,29 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/core@7.24.4:
+    resolution: {integrity: sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.24.2
+      '@babel/generator': 7.24.4
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.4)
+      '@babel/helpers': 7.24.4
+      '@babel/parser': 7.24.4
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.1
+      '@babel/types': 7.24.0
+      convert-source-map: 2.0.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/generator@7.24.1:
     resolution: {integrity: sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==}
     engines: {node: '>=6.9.0'}
@@ -285,6 +325,23 @@ packages:
       jsesc: 2.5.2
     dev: true
 
+  /@babel/generator@7.24.4:
+    resolution: {integrity: sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.0
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/helper-annotate-as-pure@7.22.5:
+    resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.0
+    dev: true
+
   /@babel/helper-compilation-targets@7.23.6:
     resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
     engines: {node: '>=6.9.0'}
@@ -293,6 +350,24 @@ packages:
       '@babel/helper-validator-option': 7.23.5
       browserslist: 4.23.0
       lru-cache: 5.1.1
+      semver: 6.3.1
+    dev: true
+
+  /@babel/helper-create-class-features-plugin@7.24.4(@babel/core@7.24.4):
+    resolution: {integrity: sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-member-expression-to-functions': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.4)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
     dev: true
 
@@ -311,6 +386,13 @@ packages:
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.0
+    dev: true
+
+  /@babel/helper-member-expression-to-functions@7.23.0:
+    resolution: {integrity: sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.0
@@ -337,13 +419,53 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
     dev: true
 
+  /@babel/helper-module-transforms@7.23.3(@babel/core@7.24.4):
+    resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.24.3
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.20
+    dev: true
+
+  /@babel/helper-optimise-call-expression@7.22.5:
+    resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.0
+    dev: true
+
   /@babel/helper-plugin-utils@7.24.0:
     resolution: {integrity: sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==}
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/helper-replace-supers@7.24.1(@babel/core@7.24.4):
+    resolution: {integrity: sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-member-expression-to-functions': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
+    dev: true
+
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.0
+    dev: true
+
+  /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
+    resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.0
@@ -380,6 +502,17 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helpers@7.24.4:
+    resolution: {integrity: sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.1
+      '@babel/types': 7.24.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/highlight@7.24.2:
     resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
     engines: {node: '>=6.9.0'}
@@ -396,6 +529,46 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.24.0
+
+  /@babel/parser@7.24.4:
+    resolution: {integrity: sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.24.0
+    dev: true
+
+  /@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.24.4):
+    resolution: {integrity: sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-plugin-utils': 7.24.0
+    dev: true
+
+  /@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.24.4):
+    resolution: {integrity: sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-plugin-utils': 7.24.0
+    dev: true
+
+  /@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.24.4):
+    resolution: {integrity: sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.4)
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-simple-access': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-react-jsx-self@7.24.1(@babel/core@7.24.3):
     resolution: {integrity: sha512-kDJgnPujTmAZ/9q2CN4m2/lRsUUPDvsG3+tSHWUJIzMGTt5U/b/fwWd3RO3n+5mjLrsBrVa5eKFRVSQbi3dF1w==}
@@ -415,6 +588,33 @@ packages:
     dependencies:
       '@babel/core': 7.24.3
       '@babel/helper-plugin-utils': 7.24.0
+    dev: true
+
+  /@babel/plugin-transform-typescript@7.24.4(@babel/core@7.24.4):
+    resolution: {integrity: sha512-79t3CQ8+oBGk/80SQ8MN3Bs3obf83zJ0YZjDmDaEZN8MqhMI760apl5z6a20kFeMXBwJX99VpKT8CKxEBp5H1g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.24.4)
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.4)
+    dev: true
+
+  /@babel/preset-typescript@7.24.1(@babel/core@7.24.4):
+    resolution: {integrity: sha512-1DBaMmRDpuYQBPWD8Pf/WEwCrtgRHxsZnP4mIy9G/X+hFfbI47Q2G4t1Paakld84+qsk2fSsUPMKg71jkoOOaQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-validator-option': 7.23.5
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.4)
+      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.4)
+      '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.24.4)
     dev: true
 
   /@babel/template@7.24.0:
@@ -1154,6 +1354,24 @@ packages:
       vite: 6.0.0-alpha.6(@types/node@20.11.30)
     dev: true
 
+  /@iconify/types@2.0.0:
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+    dev: true
+
+  /@iconify/utils@2.1.23:
+    resolution: {integrity: sha512-YGNbHKM5tyDvdWZ92y2mIkrfvm5Fvhe6WJSkWu7vvOFhMtYDP0casZpoRz0XEHZCrYsR4stdGT3cZ52yp5qZdQ==}
+    dependencies:
+      '@antfu/install-pkg': 0.1.1
+      '@antfu/utils': 0.7.7
+      '@iconify/types': 2.0.0
+      debug: 4.3.4
+      kolorist: 1.8.0
+      local-pkg: 0.5.0
+      mlly: 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1249,6 +1467,24 @@ packages:
     hasBin: true
     dependencies:
       playwright: 1.42.1
+    dev: true
+
+  /@polka/url@1.0.0-next.25:
+    resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
+    dev: true
+
+  /@rollup/pluginutils@5.1.0:
+    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
     dev: true
 
   /@rollup/rollup-android-arm-eabi@4.13.0:
@@ -1425,6 +1661,220 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
+    dev: true
+
+  /@unocss/astro@0.59.4(vite@6.0.0-alpha.6):
+    resolution: {integrity: sha512-DU3OR5MMR1Uvvec4/wB9EetDASHRg19Moy6z/MiIhn8JWJ0QzWYgSeJcfUX8exomMYv6WUEQJL+CyLI34Wmn8w==}
+    peerDependencies:
+      vite: 6.0.0-alpha.6
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      '@unocss/core': 0.59.4
+      '@unocss/reset': 0.59.4
+      '@unocss/vite': 0.59.4(vite@6.0.0-alpha.6)
+      vite: 6.0.0-alpha.6(@types/node@20.11.30)
+    transitivePeerDependencies:
+      - rollup
+    dev: true
+
+  /@unocss/cli@0.59.4:
+    resolution: {integrity: sha512-TT+WKedSifhsRqnpoYD2LfyYipVzEbzIU4DDGIaDNeDxGXYOGpb876zzkPDcvZSpI37IJ/efkkV7PGYpPBcQBQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@rollup/pluginutils': 5.1.0
+      '@unocss/config': 0.59.4
+      '@unocss/core': 0.59.4
+      '@unocss/preset-uno': 0.59.4
+      cac: 6.7.14
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      consola: 3.2.3
+      fast-glob: 3.3.2
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+    transitivePeerDependencies:
+      - rollup
+    dev: true
+
+  /@unocss/config@0.59.4:
+    resolution: {integrity: sha512-h3yhj+D5Ygn5R7gbK4wMrtXZX6FF5DF6YD517sSSb0XB3lxHD9PhhT4HaV1hpHknvu0cMFU3460M45+TN1TI0Q==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@unocss/core': 0.59.4
+      unconfig: 0.3.13
+    dev: true
+
+  /@unocss/core@0.59.4:
+    resolution: {integrity: sha512-bBZ1sgcAtezQVZ1BST9IS3jqcsTLyqKNjiIf7FTnX3DHpfpYuMDFzSOtmkZDzBleOLO/CtcRWjT0HwTSQAmV0A==}
+    dev: true
+
+  /@unocss/extractor-arbitrary-variants@0.59.4:
+    resolution: {integrity: sha512-RDe4FgMGJQ+tp9GLvhPHni7Cc2O0lHBRMElVlN8LoXJAdODMICdbrEPGJlEfrc+7x/QgVFoR895KpYJh3hIgGA==}
+    dependencies:
+      '@unocss/core': 0.59.4
+    dev: true
+
+  /@unocss/inspector@0.59.4:
+    resolution: {integrity: sha512-QczJFNDiggmekkJyNcbcZIUVwlhvxz7ZwjnSf0w7K4znxfjKkZ1hNUbqLviM1HumkTKOdT27VISW7saN/ysO4w==}
+    dependencies:
+      '@unocss/core': 0.59.4
+      '@unocss/rule-utils': 0.59.4
+      gzip-size: 6.0.0
+      sirv: 2.0.4
+    dev: true
+
+  /@unocss/postcss@0.59.4(postcss@8.4.38):
+    resolution: {integrity: sha512-KVz+AD7McHKp7VEWHbFahhyyVEo0oP/e1vnuNSuPlHthe+1V2zfH6lps+iJcvfL2072r5J+0PvD/1kOp5ryUSg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      postcss: ^8.4.21
+    dependencies:
+      '@unocss/config': 0.59.4
+      '@unocss/core': 0.59.4
+      '@unocss/rule-utils': 0.59.4
+      css-tree: 2.3.1
+      fast-glob: 3.3.2
+      magic-string: 0.30.10
+      postcss: 8.4.38
+    dev: true
+
+  /@unocss/preset-attributify@0.59.4:
+    resolution: {integrity: sha512-BeogWuYaIakC1gmOZFFCjFVWmu/m3AqEX8UYQS6tY6lAaK2L4Qf4AstYBlT2zAMxy9LNxPDxFQrvfSfFk5Klsg==}
+    dependencies:
+      '@unocss/core': 0.59.4
+    dev: true
+
+  /@unocss/preset-icons@0.59.4:
+    resolution: {integrity: sha512-Afjwh5oC4KRE8TNZDUkRK6hvvV1wKLrS1e5trniE0B0AM9HK3PBolQaIU7QmzPv6WQrog+MZgIwafg1eqsPUCA==}
+    dependencies:
+      '@iconify/utils': 2.1.23
+      '@unocss/core': 0.59.4
+      ofetch: 1.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@unocss/preset-mini@0.59.4:
+    resolution: {integrity: sha512-ZLywGrXi1OCr4My5vX2rLUb5Xgx6ufR9WTQOvpQJGBdIV/jnZn/pyE5avCs476SnOq2K172lnd8mFmTK7/zArA==}
+    dependencies:
+      '@unocss/core': 0.59.4
+      '@unocss/extractor-arbitrary-variants': 0.59.4
+      '@unocss/rule-utils': 0.59.4
+    dev: true
+
+  /@unocss/preset-tagify@0.59.4:
+    resolution: {integrity: sha512-vWMdTUoghOSmTbdmZtERssffmdUdOuhh4vUdl0R8Kv6KxB0PkvEFCu2FItn97nRJdSPlZSFxxDkaOIg9w+STNQ==}
+    dependencies:
+      '@unocss/core': 0.59.4
+    dev: true
+
+  /@unocss/preset-typography@0.59.4:
+    resolution: {integrity: sha512-ZX9bxZUqlXK1qEDzO5lkK96ICt9itR/oNyn/7mMc1JPqwj263LumQMn5silocgzoLSUXEeq//L6GylqYjkL8GA==}
+    dependencies:
+      '@unocss/core': 0.59.4
+      '@unocss/preset-mini': 0.59.4
+    dev: true
+
+  /@unocss/preset-uno@0.59.4:
+    resolution: {integrity: sha512-G1f8ZluplvXZ3bERj+sM/8zzY//XD++nNOlAQNKOANSVht3qEoJebrfEiMClNpA5qW5VWOZhEhPkh0M7GsXtnA==}
+    dependencies:
+      '@unocss/core': 0.59.4
+      '@unocss/preset-mini': 0.59.4
+      '@unocss/preset-wind': 0.59.4
+      '@unocss/rule-utils': 0.59.4
+    dev: true
+
+  /@unocss/preset-web-fonts@0.59.4:
+    resolution: {integrity: sha512-ehutTjKHnf2KPmdatN42N9a8+y+glKSU3UlcBRNsVIIXVIlaBQuPVGZSPhnMtrKD17IgWylXq2K6RJK+ab0hZA==}
+    dependencies:
+      '@unocss/core': 0.59.4
+      ofetch: 1.3.4
+    dev: true
+
+  /@unocss/preset-wind@0.59.4:
+    resolution: {integrity: sha512-CNX6w0ZpSQg/i1oF0/WKWzto8PtLqoknC5h8JmmcGb7VsyBQeV0oNnhbURxpbuMEhbv1MWVIGvk8a+P6y0rFkQ==}
+    dependencies:
+      '@unocss/core': 0.59.4
+      '@unocss/preset-mini': 0.59.4
+      '@unocss/rule-utils': 0.59.4
+    dev: true
+
+  /@unocss/reset@0.59.4:
+    resolution: {integrity: sha512-Upy4xzdWl4RChbLAXBq1BoR4WqxXMoIfjvtcwSZcZK2sylXCFAseSWnyzJFdSiXPqNfmMuNgPXgiSxiQB+cmNA==}
+    dev: true
+
+  /@unocss/rule-utils@0.59.4:
+    resolution: {integrity: sha512-1qoLJlBWAkS4D4sg73990S1MT7E8E5md/YhopKjTQuEC9SyeVmEg+5pR/Xd8xhPKMqbcuBPl/DS8b6l/GQO56A==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@unocss/core': 0.59.4
+      magic-string: 0.30.10
+    dev: true
+
+  /@unocss/scope@0.59.4:
+    resolution: {integrity: sha512-wBQJ39kw4Tfj4km7AoGvSIobPKVnRZVsgc0bema5Y0PL3g1NeVQ/LopBI2zEJWdpxGXUWxSDsXm7BZo6qVlD/A==}
+    dev: true
+
+  /@unocss/transformer-attributify-jsx-babel@0.59.4:
+    resolution: {integrity: sha512-xtCRSgeTaDBiNJLVX7oOSFe63JiFB5nrdK23PHn3IlZM9O7Bxx4ZxI3MQJtFZFQNE+INFko+DVyY1WiFEm1p/Q==}
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.4)
+      '@babel/preset-typescript': 7.24.1(@babel/core@7.24.4)
+      '@unocss/core': 0.59.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@unocss/transformer-attributify-jsx@0.59.4:
+    resolution: {integrity: sha512-m4b83utzKMfUQH/45V2QkjJoXd8Tu2pRP1nic91Xf7QRceyKDD+BxoTneo2JNC2K274cQu7HqqotnCm2aFfEGw==}
+    dependencies:
+      '@unocss/core': 0.59.4
+    dev: true
+
+  /@unocss/transformer-compile-class@0.59.4:
+    resolution: {integrity: sha512-Vgk2OCLPW0pU+Uzr1IgDtHVspSBb+gPrQFkV+5gxHk9ZdKi3oYKxLuufVWYDSwv7o9yfQGbYrMH9YLsjRsnA7Q==}
+    dependencies:
+      '@unocss/core': 0.59.4
+    dev: true
+
+  /@unocss/transformer-directives@0.59.4:
+    resolution: {integrity: sha512-nXUTEclUbs0vQ4KfLhKt4J/5SLSEq1az2FNlJmiXMmqmn75X89OrtCu2OJu9sGXhn+YyBApxgcSSdxmtpqMi1Q==}
+    dependencies:
+      '@unocss/core': 0.59.4
+      '@unocss/rule-utils': 0.59.4
+      css-tree: 2.3.1
+    dev: true
+
+  /@unocss/transformer-variant-group@0.59.4:
+    resolution: {integrity: sha512-9XLixxn1NRgP62Kj4R/NC/rpqhql5F2s6ulJ8CAMTEbd/NylVhEANluPGDVUGcLJ4cj6E02hFa8C1PLGSm7/xw==}
+    dependencies:
+      '@unocss/core': 0.59.4
+    dev: true
+
+  /@unocss/vite@0.59.4(vite@6.0.0-alpha.6):
+    resolution: {integrity: sha512-q7GN7vkQYn79n7vYIUlaa7gXGwc7pk0Qo3z3ZFwWGE43/DtZnn2Hwl5UjgBAgi9McA+xqHJEHRsJnI7HJPHUYA==}
+    peerDependencies:
+      vite: 6.0.0-alpha.6
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@rollup/pluginutils': 5.1.0
+      '@unocss/config': 0.59.4
+      '@unocss/core': 0.59.4
+      '@unocss/inspector': 0.59.4
+      '@unocss/scope': 0.59.4
+      '@unocss/transformer-directives': 0.59.4
+      chokidar: 3.6.0
+      fast-glob: 3.3.2
+      magic-string: 0.30.10
+      vite: 6.0.0-alpha.6(@types/node@20.11.30)
+    transitivePeerDependencies:
+      - rollup
     dev: true
 
   /@vitejs/plugin-react@4.2.1(vite@6.0.0-alpha.6):
@@ -1974,6 +2424,10 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
+  /colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+    dev: true
+
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: false
@@ -1991,6 +2445,11 @@ packages:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
     dev: true
 
+  /consola@3.2.3:
+    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+    dev: true
+
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
@@ -2006,6 +2465,14 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
+
+  /css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+    dependencies:
+      mdn-data: 2.0.30
+      source-map-js: 1.2.0
     dev: true
 
   /csstype@3.1.3:
@@ -2036,6 +2503,14 @@ packages:
       type-detect: 4.0.8
     dev: true
 
+  /defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+    dev: true
+
+  /destr@2.0.3:
+    resolution: {integrity: sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==}
+    dev: true
+
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2046,6 +2521,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+    dev: true
+
+  /duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: true
 
   /eastasianwidth@0.2.0:
@@ -2299,6 +2778,14 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
 
+  /find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+    dev: true
+
   /foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
@@ -2397,6 +2884,13 @@ packages:
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: false
+
+  /gzip-size@6.0.0:
+    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      duplexer: 0.1.2
+    dev: true
 
   /happy-dom@14.7.1:
     resolution: {integrity: sha512-v60Q0evZ4clvMcrAh5/F8EdxDdfHdFrtffz/CNe10jKD+nFweZVxM91tW+UyY2L4AtpgIaXdZ7TQmiO1pfcwbg==}
@@ -2505,6 +2999,11 @@ packages:
       supports-color: 8.1.1
     dev: false
 
+  /jiti@1.21.0:
+    resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
+    hasBin: true
+    dev: true
+
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -2537,6 +3036,10 @@ packages:
     hasBin: true
     dev: true
 
+  /kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+    dev: true
+
   /lilconfig@3.1.1:
     resolution: {integrity: sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==}
     engines: {node: '>=14'}
@@ -2562,6 +3065,13 @@ packages:
     dependencies:
       mlly: 1.6.1
       pkg-types: 1.1.0
+    dev: true
+
+  /locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-locate: 5.0.0
     dev: true
 
   /lodash.sortby@4.7.0:
@@ -2604,11 +3114,21 @@ packages:
     dependencies:
       sourcemap-codec: 1.4.8
 
+  /magic-string@0.30.10:
+    resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
   /magic-string@0.30.9:
     resolution: {integrity: sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  /mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+    dev: true
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2694,6 +3214,11 @@ packages:
       ufo: 1.5.3
     dev: true
 
+  /mrmime@2.0.0:
+    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
+    engines: {node: '>=10'}
+    dev: true
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -2726,6 +3251,10 @@ packages:
     resolution: {integrity: sha512-69mtXOFZ6hSkYiXAVB5SqaRvrbITC/NPyqv7yuu/qw0nmgPyYbIMYYNIDhNtwPrzk0ptrimrLz/hhjvm4w5Z+w==}
     dev: true
 
+  /node-fetch-native@1.6.4:
+    resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
+    dev: true
+
   /node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
@@ -2756,6 +3285,14 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /ofetch@1.3.4:
+    resolution: {integrity: sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==}
+    dependencies:
+      destr: 2.0.3
+      node-fetch-native: 1.6.4
+      ufo: 1.5.3
+    dev: true
+
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -2770,6 +3307,13 @@ packages:
       mimic-fn: 4.0.0
     dev: true
 
+  /p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      yocto-queue: 0.1.0
+    dev: true
+
   /p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
@@ -2777,8 +3321,20 @@ packages:
       yocto-queue: 1.0.0
     dev: true
 
+  /p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-limit: 3.1.0
+    dev: true
+
   /path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: true
+
+  /path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
     dev: true
 
   /path-key@3.1.1:
@@ -2816,6 +3372,10 @@ packages:
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
+
+  /perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
     dev: true
 
   /picocolors@1.0.0:
@@ -3135,6 +3695,15 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.25
+      mrmime: 2.0.0
+      totalist: 3.0.1
+    dev: true
+
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3347,6 +3916,11 @@ packages:
     dependencies:
       is-number: 7.0.0
 
+  /totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+    dev: true
+
   /tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
     dependencies:
@@ -3429,6 +4003,14 @@ packages:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
     dev: true
 
+  /unconfig@0.3.13:
+    resolution: {integrity: sha512-N9Ph5NC4+sqtcOjPfHrRcHekBCadCXWTBzp2VYYbySOHW0PfD9XLCeXshTXjkPYwLrBr9AtSeU0CZmkYECJhng==}
+    dependencies:
+      '@antfu/utils': 0.7.7
+      defu: 6.1.4
+      jiti: 1.21.0
+    dev: true
+
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
@@ -3437,6 +4019,45 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.1
+
+  /unocss@0.59.4(postcss@8.4.38)(vite@6.0.0-alpha.6):
+    resolution: {integrity: sha512-QmCVjRObvVu/gsGrJGVt0NnrdhFFn314BUZn2WQyXV9rIvHLRmG5bIu0j5vibJkj7ZhFchTrnTM1pTFXP1xt5g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@unocss/webpack': 0.59.4
+      vite: 6.0.0-alpha.6
+    peerDependenciesMeta:
+      '@unocss/webpack':
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@unocss/astro': 0.59.4(vite@6.0.0-alpha.6)
+      '@unocss/cli': 0.59.4
+      '@unocss/core': 0.59.4
+      '@unocss/extractor-arbitrary-variants': 0.59.4
+      '@unocss/postcss': 0.59.4(postcss@8.4.38)
+      '@unocss/preset-attributify': 0.59.4
+      '@unocss/preset-icons': 0.59.4
+      '@unocss/preset-mini': 0.59.4
+      '@unocss/preset-tagify': 0.59.4
+      '@unocss/preset-typography': 0.59.4
+      '@unocss/preset-uno': 0.59.4
+      '@unocss/preset-web-fonts': 0.59.4
+      '@unocss/preset-wind': 0.59.4
+      '@unocss/reset': 0.59.4
+      '@unocss/transformer-attributify-jsx': 0.59.4
+      '@unocss/transformer-attributify-jsx-babel': 0.59.4
+      '@unocss/transformer-compile-class': 0.59.4
+      '@unocss/transformer-directives': 0.59.4
+      '@unocss/transformer-variant-group': 0.59.4
+      '@unocss/vite': 0.59.4(vite@6.0.0-alpha.6)
+      vite: 6.0.0-alpha.6(@types/node@20.11.30)
+    transitivePeerDependencies:
+      - postcss
+      - rollup
+      - supports-color
+    dev: true
 
   /update-browserslist-db@1.0.13(browserslist@4.23.0):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
@@ -3809,6 +4430,11 @@ packages:
     resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
     engines: {node: '>= 14'}
     hasBin: true
+    dev: true
+
+  /yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
     dev: true
 
   /yocto-queue@1.0.0:


### PR DESCRIPTION
Experimenting with `Plugin.create` and `sharedDuringBuild` introduced in https://github.com/vitejs/vite/pull/16471#issuecomment-2079112465

## summary

- Token extraction is done for all environments using `transform` hook
- `virtual:unocss.css` imported only by client environment
  - During dev, this will sets up HMR via `environment.hot`
  - During build, this will sets up "delayed" css transform based on `renderChunk` + `vite:css-post` trick.
    Since the build order is `react-server -> client`, at the time of client `renderChunk`, it has collected all tokens from both environments.

## todo

- [x] dev, hmr, fouc
- [x] build
- [x] test
- [ ] feedback
  - `create` is awesome
    - since `create(environment)` already gives `environment.moduleGraph`, `hot`, etc... during dev, `configureServer(server)` was not necessary.