### PR TITLE
fix: fix html replace

### DIFF
--- a/examples/react-ssr-workerd/src/entry-server.tsx
+++ b/examples/react-ssr-workerd/src/entry-server.tsx
@@ -13,7 +13,7 @@ export async function handler(request: Request) {
 
   const ssrHtml = ReactDomServer.renderToString(<Page />);
   let html = (await import("virtual:index-html")).default;
-  html = html.replace(/<body>/, `<body><div id="root">${ssrHtml}</div>`);
+  html = html.replace("<body>", () => `<body><div id="root">${ssrHtml}</div>`);
   return new Response(html, { headers: { "content-type": "text/html" } });
 }
 

--- a/examples/react-ssr/src/entry-server.tsx
+++ b/examples/react-ssr/src/entry-server.tsx
@@ -4,6 +4,6 @@ import Page from "./routes/page";
 export async function handler(_req: Request) {
   const ssrHtml = ReactDomServer.renderToString(<Page />);
   let html = (await import("virtual:index-html")).default;
-  html = html.replace(/<body>/, `<body><div id="root">${ssrHtml}</div>`);
+  html = html.replace("<body>", () => `<body><div id="root">${ssrHtml}</div>`);
   return new Response(html, { headers: { "content-type": "text/html" } });
 }

--- a/examples/vue-ssr-extra/src/entry-server.ts
+++ b/examples/vue-ssr-extra/src/entry-server.ts
@@ -33,10 +33,11 @@ export async function handler(request: Request) {
   const ssrHtml = await renderToString(app);
 
   let html = (await import("virtual:index-html")).default;
-  html = html.replace("<body>", `<body><div id="root">${ssrHtml}</div>`);
+  html = html.replace("<body>", () => `<body><div id="root">${ssrHtml}</div>`);
   html = html.replace(
     "<head>",
-    `<head><script>globalThis.__serverPiniaState = ${JSON.stringify(pinia.state.value)}</script>`,
+    () =>
+      `<head><script>globalThis.__serverPiniaState = ${JSON.stringify(pinia.state.value)}</script>`,
   );
   // dev only FOUC fix
   if (import.meta.env.DEV) {


### PR DESCRIPTION
I forgot about the special behavior of `$$`:

```js
> "hello".replace("hello", "$$id")
'$id'
```