### PR TITLE
fix(react-server): fix `?import` query dual package

### DIFF
--- a/examples/react-server/src/basic.test.tsx
+++ b/examples/react-server/src/basic.test.tsx
@@ -7,7 +7,7 @@ import { initializeWebpackBrowser } from "./features/use-client/browser";
 
 beforeAll(() => {
   // doing the same as examples/react-server/src/features/bootstrap/plugin.ts
-  (globalThis as any).__dev_import = (id: string) =>
+  (globalThis as any).__raw_import = (id: string) =>
     import(/* @vite-ignore */ id);
 });
 

--- a/examples/react-server/src/basic.test.tsx
+++ b/examples/react-server/src/basic.test.tsx
@@ -2,8 +2,14 @@ import { createManualPromise } from "@hiogawa/utils";
 import { Window } from "happy-dom";
 import React from "react";
 import reactDomClient from "react-dom/client";
-import { beforeEach, expect, test, vi } from "vitest";
+import { beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { initializeWebpackBrowser } from "./features/use-client/browser";
+
+beforeAll(() => {
+  // doing the same as examples/react-server/src/features/bootstrap/plugin.ts
+  (globalThis as any).__dev_import = (id: string) =>
+    import(/* @vite-ignore */ id);
+});
 
 // happy-dom
 beforeEach(() => {

--- a/examples/react-server/src/features/bootstrap/plugin.ts
+++ b/examples/react-server/src/features/bootstrap/plugin.ts
@@ -34,7 +34,11 @@ export function vitePluginEntryBootstrap(): PluginOption {
     createVirtualPlugin("ssr-assets", async () => {
       let ssrAssets: SsrAssets;
       if ($__global.server) {
-        const { head } = await getIndexHtmlTransform($__global.server);
+        let { head } = await getIndexHtmlTransform($__global.server);
+        // expose raw dynamic `import` to avoid vite's import analysis `?import` injection
+        // when vite transforms `import(/* @vite-ignore */ id)`..
+        // see examples/react-server/src/features/use-client/browser.ts
+        head += `<script>globalThis.__dev_import = (id) => import(id)</script>\n`;
         ssrAssets = {
           head,
           bootstrapModules: ["/@id/__x00__" + ENTRY_CLIENT_BOOTSTRAP],

--- a/examples/react-server/src/features/bootstrap/plugin.ts
+++ b/examples/react-server/src/features/bootstrap/plugin.ts
@@ -38,7 +38,7 @@ export function vitePluginEntryBootstrap(): PluginOption {
         // expose raw dynamic `import` to avoid vite's import analysis `?import` injection
         // when vite transforms `import(/* @vite-ignore */ id)`..
         // see examples/react-server/src/features/use-client/browser.ts
-        head += `<script>globalThis.__dev_import = (id) => import(id)</script>\n`;
+        head += `<script>globalThis.__raw_import = (id) => import(id)</script>\n`;
         ssrAssets = {
           head,
           bootstrapModules: ["/@id/__x00__" + ENTRY_CLIENT_BOOTSTRAP],

--- a/examples/react-server/src/features/use-client/browser.ts
+++ b/examples/react-server/src/features/use-client/browser.ts
@@ -2,8 +2,8 @@ import { memoize, tinyassert } from "@hiogawa/utils";
 
 async function importWrapper(id: string) {
   if (import.meta.env.DEV) {
-    // `__dev_import` injected by examples/react-server/src/features/bootstrap/plugin.ts
-    return (globalThis as any).__dev_import(id);
+    // `__raw_import` injected by examples/react-server/src/features/bootstrap/plugin.ts
+    return (globalThis as any).__raw_import(id);
   } else {
     const clientReferences = await import("virtual:client-reference" as string);
     const dynImport = clientReferences.default[id];

--- a/examples/react-server/src/features/use-client/browser.ts
+++ b/examples/react-server/src/features/use-client/browser.ts
@@ -2,7 +2,8 @@ import { memoize, tinyassert } from "@hiogawa/utils";
 
 async function importWrapper(id: string) {
   if (import.meta.env.DEV) {
-    return import(/* @vite-ignore */ id);
+    // `__dev_import` injected by examples/react-server/src/features/bootstrap/plugin.ts
+    return (globalThis as any).__dev_import(id);
   } else {
     const clientReferences = await import("virtual:client-reference" as string);
     const dynImport = clientReferences.default[id];


### PR DESCRIPTION
It looks like Jacob avoids this since client reference `import` happens in raw script
https://github.com/jacob-ebey/vite-env-api/blob/329affdf8bd63094cce89902470adffb904809af/vite/src/plugin.ts#L441

We can do something similar by exposing `import` wrapper to avoids vite's `?import` transform?