### PR TITLE
refactor(react-server): identity bundler config

### DIFF
--- a/examples/react-server/src/entry-ssr.tsx
+++ b/examples/react-server/src/entry-ssr.tsx
@@ -2,10 +2,7 @@ import { splitFirst } from "@hiogawa/utils";
 import React from "react";
 import reactDomServer from "react-dom/server.edge";
 import type { ReactServerHandlerResult, StreamData } from "./entry-server";
-import {
-  createModuleMap,
-  initializeWebpackServer,
-} from "./features/use-client/ssr";
+import { initializeWebpackServer } from "./features/use-client/ssr";
 import { injectStreamScript } from "./features/utils/stream-script";
 import { $__global } from "./global";
 
@@ -33,7 +30,7 @@ async function renderHtml(result: ReactServerHandlerResult) {
     rscStream1,
     {
       ssrManifest: {
-        moduleMap: createModuleMap(),
+        moduleMap: null,
         moduleLoading: null,
       },
     },

--- a/examples/react-server/src/features/use-client/ssr.ts
+++ b/examples/react-server/src/features/use-client/ssr.ts
@@ -1,5 +1,4 @@
 import { memoize, tinyassert } from "@hiogawa/utils";
-import type { ImportManifestEntry, ModuleMap } from "../../types";
 
 // In contrast to old dev ssr, new module runner's dynamic `import`
 // with `vite-ignore` joins in a module graph.
@@ -26,28 +25,4 @@ export function initializeWebpackServer() {
       throw new Error("todo: __webpack_chunk_load__");
     },
   });
-}
-
-export function createModuleMap(): ModuleMap {
-  return new Proxy(
-    {},
-    {
-      get(_target, id, _receiver) {
-        return new Proxy(
-          {},
-          {
-            get(_target, name, _receiver) {
-              tinyassert(typeof id === "string");
-              tinyassert(typeof name === "string");
-              return {
-                id,
-                name,
-                chunks: [],
-              } satisfies ImportManifestEntry;
-            },
-          },
-        );
-      },
-    },
-  );
 }

--- a/examples/react-server/src/types/index.ts
+++ b/examples/react-server/src/types/index.ts
@@ -21,8 +21,8 @@ export type ModuleMap = {
 };
 
 export interface SsrManifest {
-  moduleMap: ModuleMap;
-  // TODO
+  // identity mapping should suffice?
+  moduleMap: ModuleMap | null;
   moduleLoading: null;
 }
 


### PR DESCRIPTION
As I started to read react flight more, it looks like identity bundler config on ssr is not necessary just like browser doesn't do it already.

https://github.com/facebook/react/blob/149b917c8a4022aeaa170c4fb826107dd2333c68/packages/react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack.js#L65-L68
