### PR TITLE
chore: inline uno.config.ts

### DIFF
--- a/examples/react-server/src/features/unocss/plugin.ts
+++ b/examples/react-server/src/features/unocss/plugin.ts
@@ -1,5 +1,6 @@
 import { debounce, objectHas, tinyassert } from "@hiogawa/utils";
 import vitePluginUnocss, { type UnocssVitePluginAPI } from "@unocss/vite";
+import { defineConfig, presetUno, transformerVariantGroup } from "unocss";
 import {
   type BoundedPlugin,
   type BoundedPluginConstructor,
@@ -14,12 +15,16 @@ import { createVirtualPlugin } from "../utils/plugin";
 // https://github.com/unocss/unocss/tree/47eafba27619ed26579df60fe3fdeb6122b5093c/packages/vite/src/modes/global
 // https://github.com/tailwindlabs/tailwindcss/blob/719c0d488378002ff752e8dc7199c843930bb296/packages/%40tailwindcss-vite/src/index.ts
 
-// TODO:
-// reading `uno.config.ts` is adding more than 1 sec on startup time. is it normal?
+// inline `uno.config.ts` since loading it from a file is taking more than 1 sec
+// TODO: investigate to see if this is related to Vite 6
+const unocssConfig = defineConfig({
+  presets: [presetUno()],
+  transformers: [transformerVariantGroup()],
+});
 
 export function vitePluginSharedUnocss(): PluginOption {
   // reuse original plugin to grab internal unocss instance and transform plugins
-  const originalPlugins = vitePluginUnocss();
+  const originalPlugins = vitePluginUnocss(unocssConfig);
   const apiPlugin = originalPlugins.find((p) => p.name === "unocss:api");
   tinyassert(apiPlugin);
   const ctx = (apiPlugin.api as UnocssVitePluginAPI).getContext();

--- a/examples/react-server/uno.config.ts
+++ b/examples/react-server/uno.config.ts
@@ -1,6 +1,0 @@
-import { defineConfig, presetUno, transformerVariantGroup } from "unocss";
-
-export default defineConfig({
-  presets: [presetUno()],
-  transformers: [transformerVariantGroup()],
-});


### PR DESCRIPTION
Start up taking more than 1 sec is not really pretty as a quick demo, so let's hide it for now.

```sh
# before
$ pnpm -C examples/react-server dev
...
  VITE v6.0.0-alpha.10  ready in 1783 ms

# after
$ pnpm -C examples/react-server dev
...
  VITE v6.0.0-alpha.10  ready in 307 ms
```