### PR TITLE
chore: replace hattip node adapter

### DIFF
--- a/examples/react-server/src/adapters/node.tsx
+++ b/examples/react-server/src/adapters/node.tsx
@@ -1,4 +1,4 @@
-import { createMiddleware } from "@hattip/adapter-node/native-fetch";
+import { getRequestListener } from "@hono/node-server";
 import { handler } from "../entry-ssr";
 
-export default createMiddleware((ctx) => handler(ctx.request));
+export default getRequestListener(handler);

--- a/examples/react-ssr-workerd/src/adapters/node.tsx
+++ b/examples/react-ssr-workerd/src/adapters/node.tsx
@@ -1,4 +1,4 @@
-import { createMiddleware } from "@hattip/adapter-node/native-fetch";
+import { getRequestListener } from "@hono/node-server";
 import { handler } from "../entry-server";
 
-export default createMiddleware((ctx) => handler(ctx.request));
+export default getRequestListener(handler);

--- a/examples/react-ssr/src/adapters/node.tsx
+++ b/examples/react-ssr/src/adapters/node.tsx
@@ -1,4 +1,4 @@
-import { createMiddleware } from "@hattip/adapter-node/native-fetch";
+import { getRequestListener } from "@hono/node-server";
 import { handler } from "../entry-server";
 
-export default createMiddleware((ctx) => handler(ctx.request));
+export default getRequestListener(handler);

--- a/examples/vue-ssr-extra/src/features/server-action/server.ts
+++ b/examples/vue-ssr-extra/src/features/server-action/server.ts
@@ -19,7 +19,7 @@ export async function serverActionHandler({ request }: { request: Request }) {
   return new Response(null, {
     status: 302,
     headers: {
-      location: request.url,
+      Location: url.href.slice(url.origin.length),
     },
   });
 }

--- a/examples/vue-ssr/src/adapters/node.tsx
+++ b/examples/vue-ssr/src/adapters/node.tsx
@@ -1,4 +1,4 @@
-import { createMiddleware } from "@hattip/adapter-node/native-fetch";
+import { getRequestListener } from "@hono/node-server";
 import { handler } from "../entry-server";
 
-export default createMiddleware((ctx) => handler(ctx.request));
+export default getRequestListener(handler);

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.7.3",
-    "@hattip/adapter-node": "^0.0.44",
     "@hiogawa/utils": "1.6.4-pre.1",
     "@hiogawa/vite-plugin-ssr-middleware": "^0.0.3",
+    "@hono/node-server": "^1.11.1",
     "@playwright/test": "^1.42.1",
     "@tsconfig/strictest": "^2.0.4",
     "@types/node": "^20.11.30",

--- a/packages/workerd/src/plugin.ts
+++ b/packages/workerd/src/plugin.ts
@@ -68,8 +68,11 @@ export function vitePluginWorkerd(pluginOptions: WorkerdPluginOptions): Plugin {
         return;
       }
       const devEnv = server.environments["workerd"] as WorkerdDevEnvironment;
-      const nodeMiddleware = getRequestListener((request) =>
-        devEnv.api.dispatchFetch(entry, request),
+      const nodeMiddleware = getRequestListener(
+        (request) => devEnv.api.dispatchFetch(entry, request),
+        {
+          overrideGlobalObjects: false,
+        },
       );
       return () => {
         server.middlewares.use(nodeMiddleware);

--- a/packages/workerd/src/plugin.ts
+++ b/packages/workerd/src/plugin.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "url";
-import { createMiddleware } from "@hattip/adapter-node/native-fetch";
 import { DefaultMap, tinyassert } from "@hiogawa/utils";
+import { getRequestListener } from "@hono/node-server";
 import {
   Miniflare,
   Response as MiniflareResponse,
@@ -68,9 +68,8 @@ export function vitePluginWorkerd(pluginOptions: WorkerdPluginOptions): Plugin {
         return;
       }
       const devEnv = server.environments["workerd"] as WorkerdDevEnvironment;
-      const nodeMiddleware = createMiddleware(
-        (ctx) => devEnv.api.dispatchFetch(entry, ctx.request),
-        { alwaysCallNext: false },
+      const nodeMiddleware = getRequestListener((request) =>
+        devEnv.api.dispatchFetch(entry, request),
       );
       return () => {
         server.middlewares.use(nodeMiddleware);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,15 +14,15 @@ importers:
       '@biomejs/biome':
         specifier: ^1.7.3
         version: 1.7.3
-      '@hattip/adapter-node':
-        specifier: ^0.0.44
-        version: 0.0.44
       '@hiogawa/utils':
         specifier: 1.6.4-pre.1
         version: 1.6.4-pre.1
       '@hiogawa/vite-plugin-ssr-middleware':
         specifier: ^0.0.3
         version: 0.0.3(vite@6.0.0-alpha.10)
+      '@hono/node-server':
+        specifier: ^1.11.1
+        version: 1.11.1
       '@playwright/test':
         specifier: ^1.42.1
         version: 1.42.1
@@ -1375,41 +1375,6 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  /@hattip/adapter-node@0.0.44:
-    resolution: {integrity: sha512-Qf0kcrE4yHFrmKgfntrxHGNkk0/9a45aKmAO3ex6OiRKat5DZCFDdFMHV85Z594IohzT7Q+WcWiHQl/b0Jvo7Q==}
-    dependencies:
-      '@hattip/core': 0.0.44
-      '@hattip/polyfills': 0.0.44
-      '@hattip/walk': 0.0.44
-    dev: true
-
-  /@hattip/core@0.0.44:
-    resolution: {integrity: sha512-hW0scygJk2FjC8lL+NAaV8eY5XtseXvX+EyORFgtURJQ33myy/epSFm7uLZcVNVU9aA0C4WyJQSza+U0rxt2Sg==}
-    dev: true
-
-  /@hattip/headers@0.0.44:
-    resolution: {integrity: sha512-bwNQ+o8RRTox9FWkmprTP8/rNki9BXkrthCDdnT5zgfkjZk6VFAloV5jmYqnqrNkh3Aw5DFGUcQJRoQBb4aQCw==}
-    dependencies:
-      '@hattip/core': 0.0.44
-    dev: true
-
-  /@hattip/polyfills@0.0.44:
-    resolution: {integrity: sha512-ldNES22u/135K8Yg6nti1djcwZeIw6e1SY/iqW0qh+AfyYNHuGTix7YL/9OKAD9wbOUj2NHqXYOGCT69NsfIqA==}
-    dependencies:
-      '@hattip/core': 0.0.44
-      '@whatwg-node/fetch': 0.9.17
-      node-fetch-native: 1.6.2
-    dev: true
-
-  /@hattip/walk@0.0.44:
-    resolution: {integrity: sha512-tjYO71byyQpdsOVKJ4cySAwWSYqU9IWbROiU1D9SqlQyEYN+TOEaB6n8YkX1gyRbLVkMe+/DJcuagm9AQdPO5A==}
-    hasBin: true
-    dependencies:
-      '@hattip/headers': 0.0.44
-      cac: 6.7.14
-      mime-types: 2.1.35
-    dev: true
-
   /@hiogawa/utils@1.6.4-pre.1:
     resolution: {integrity: sha512-L8g6kQuPKJXKoqF1XuFYXXHQ3Z4VXuEX8tlOz/gPO6uP2VQ95JUyONsr93RpVTLc/GGblXY30/YK4r56kJzzgQ==}
     dev: true
@@ -1420,6 +1385,11 @@ packages:
       vite: 6.0.0-alpha.10
     dependencies:
       vite: 6.0.0-alpha.10(@types/node@20.11.30)
+    dev: true
+
+  /@hono/node-server@1.11.1:
+    resolution: {integrity: sha512-GW1Iomhmm1o4Z+X57xGby8A35Cu9UZLL7pSMdqDBkD99U5cywff8F+8hLk5aBTzNubnsFAvWQ/fZjNwPsEn9lA==}
+    engines: {node: '>=18.14.1'}
     dev: true
 
   /@iconify/types@2.0.0:
@@ -1496,10 +1466,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-
-  /@kamilkisiela/fast-url-parser@1.1.4:
-    resolution: {integrity: sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==}
-    dev: true
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2222,30 +2188,6 @@ packages:
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@whatwg-node/events@0.1.1:
-    resolution: {integrity: sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==}
-    engines: {node: '>=16.0.0'}
-    dev: true
-
-  /@whatwg-node/fetch@0.9.17:
-    resolution: {integrity: sha512-TDYP3CpCrxwxpiNY0UMNf096H5Ihf67BK1iKGegQl5u9SlpEDYrvnV71gWBGJm+Xm31qOy8ATgma9rm8Pe7/5Q==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@whatwg-node/node-fetch': 0.5.10
-      urlpattern-polyfill: 10.0.0
-    dev: true
-
-  /@whatwg-node/node-fetch@0.5.10:
-    resolution: {integrity: sha512-KIAHepie/T1PRkUfze4t+bPlyvpxlWiXTPtcGlbIZ0vWkBJMdRmCg4ZrJ2y4XaO1eTPo1HlWYUuj1WvoIpumqg==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@kamilkisiela/fast-url-parser': 1.1.4
-      '@whatwg-node/events': 0.1.1
-      busboy: 1.6.0
-      fast-querystring: 1.1.2
-      tslib: 2.6.2
-    dev: true
-
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
     dev: false
@@ -2399,13 +2341,6 @@ packages:
     dependencies:
       esbuild: 0.19.12
       load-tsconfig: 0.2.5
-    dev: true
-
-  /busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
     dev: true
 
   /cac@6.7.14:
@@ -2805,10 +2740,6 @@ packages:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
 
-  /fast-decode-uri-component@1.0.1:
-    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
-    dev: true
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
@@ -2827,12 +2758,6 @@ packages:
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: false
-
-  /fast-querystring@1.1.2:
-    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
-    dependencies:
-      fast-decode-uri-component: 1.0.1
-    dev: true
 
   /fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -3217,12 +3142,14 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
+    dev: false
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: false
 
   /mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -3314,10 +3241,6 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: false
-
-  /node-fetch-native@1.6.2:
-    resolution: {integrity: sha512-69mtXOFZ6hSkYiXAVB5SqaRvrbITC/NPyqv7yuu/qw0nmgPyYbIMYYNIDhNtwPrzk0ptrimrLz/hhjvm4w5Z+w==}
-    dev: true
 
   /node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
@@ -3815,11 +3738,6 @@ packages:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
 
-  /streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
-    dev: true
-
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4136,10 +4054,6 @@ packages:
     dependencies:
       punycode: 2.3.1
     dev: false
-
-  /urlpattern-polyfill@10.0.0:
-    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
-    dev: true
 
   /vite-node@1.5.1(@types/node@20.11.30):
     resolution: {integrity: sha512-HNpfV7BrAsjkYVNWIcPleJwvJmydJqqJRrRbpoQ/U7QDwJKyEzNa4g5aYg8MjXJyKsk29IUCcMLFRcsEvqUIsA==}


### PR DESCRIPTION
See https://github.com/hi-ogawa/reproductions/pull/9

---

It looks like POST + 302 redirection is failing?

---

ouch, just realized there is `overrideGlobalObjects` which defaults to true...
https://github.com/honojs/node-server/blob/becc420b5d4ea51977a8e5b12e945ceb09c2ee9a/src/listener.ts#L155

Shall we try mine?
- https://github.com/hi-ogawa/js-utils/pull/252