### PR TITLE
refactor: use readdir recursive

### DIFF
--- a/examples/react-server/src/features/utils/plugin.ts
+++ b/examples/react-server/src/features/utils/plugin.ts
@@ -111,25 +111,9 @@ function replaceCode(
 //
 
 export async function collectFiles(baseDir: string) {
-  const files: string[] = [];
-  await traverseFiles(baseDir, async (filepath, e) => {
-    if (e.isFile()) {
-      files.push(filepath);
-    }
-    return e.isDirectory();
+  const files = await fs.promises.readdir(baseDir, {
+    withFileTypes: true,
+    recursive: true,
   });
-  return files;
-}
-
-async function traverseFiles(
-  dir: string,
-  callback: (filepath: string, e: fs.Dirent) => Promise<boolean>,
-) {
-  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
-  for (const e of entries) {
-    const filepath = path.join(e.path, e.name);
-    if (await callback(filepath, e)) {
-      await traverseFiles(filepath, callback);
-    }
-  }
+  return files.filter((f) => f.isFile()).map((f) => path.join(f.path, f.name));
 }

--- a/examples/vue-ssr-extra/src/features/server-action/plugin.ts
+++ b/examples/vue-ssr-extra/src/features/server-action/plugin.ts
@@ -67,27 +67,11 @@ export function vitePluginServerAction(): PluginOption {
 }
 
 async function collectFiles(baseDir: string) {
-  const files: string[] = [];
-  await traverseFiles(baseDir, async (filepath, e) => {
-    if (e.isFile()) {
-      files.push(filepath);
-    }
-    return e.isDirectory();
+  const files = await fs.promises.readdir(baseDir, {
+    withFileTypes: true,
+    recursive: true,
   });
-  return files;
-}
-
-async function traverseFiles(
-  dir: string,
-  callback: (filepath: string, e: fs.Dirent) => Promise<boolean>,
-) {
-  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
-  for (const e of entries) {
-    const filepath = path.join(e.path, e.name);
-    if (await callback(filepath, e)) {
-      await traverseFiles(filepath, callback);
-    }
-  }
+  return files.filter((f) => f.isFile()).map((f) => path.join(f.path, f.name));
 }
 
 function createVirtualPlugin(name: string, load: Plugin["load"]) {


### PR DESCRIPTION
Just recently learned `readdirve(..., { recursive: true })` exits https://github.com/hi-ogawa/js-utils/blob/9e2b46d6fd32d5fa5b909cd762cfa4aa1e65500a/packages/tiny-react/examples/server/src/integration/client-reference/plugin.ts#L25-L28