### PR TITLE
fix: fix `normalizeReferenceId`

### DIFF
--- a/examples/react-server/e2e/basic.test.ts
+++ b/examples/react-server/e2e/basic.test.ts
@@ -26,20 +26,24 @@ test("client hmr @dev", async ({ page }) => {
   await waitForHydration(page);
 
   using editor = createEditor("src/routes/_client.tsx");
-  await using reloadChecker = await createReloadChecker(page);
 
   await page.getByRole("heading", { name: "Hello Client Component" }).click();
+  await page.getByTestId("client-component").getByText("Count: 0").click();
+  await page
+    .getByTestId("client-component")
+    .getByRole("button", { name: "+" })
+    .click();
+  await page.getByTestId("client-component").getByText("Count: 1").click();
   editor.edit((s) =>
     s.replace("Hello Client Component", "Hello [EDIT] Client Component"),
   );
   await page
     .getByRole("heading", { name: "Hello [EDIT] Client Component" })
     .click();
+  await page.getByTestId("client-component").getByText("Count: 1").click();
 
-  await reloadChecker.check();
   const res = await page.reload();
   await waitForHydration(page);
-  await reloadChecker.reset();
   const resText = await res?.text();
   expect(resText).toContain("Hello [EDIT] Client Component");
 });
@@ -89,6 +93,48 @@ test("shared hmr @dev", async ({ page }) => {
   const resText = await res?.text();
   expect(resText).toContain("Shared [EDIT] Component (<!-- -->server<!-- -->)");
   expect(resText).toContain("Shared [EDIT] Component (<!-- -->client<!-- -->)");
+});
+
+// this is a test to make sure client reference points to the
+// same module as the last browser hmr module
+// cf. https://github.com/hi-ogawa/vite-plugins/pull/316
+test("mixed hmr @dev", async ({ page }) => {
+  usePageErrorChecker(page);
+  await page.goto("/");
+  await waitForHydration(page);
+
+  // browser hmr
+  using clientFile = createEditor("src/routes/_client.tsx");
+  await page.getByRole("heading", { name: "Hello Client Component" }).click();
+  await page.getByTestId("client-component").getByText("Count: 0").click();
+  await page
+    .getByTestId("client-component")
+    .getByRole("button", { name: "+" })
+    .click();
+  await page.getByTestId("client-component").getByText("Count: 1").click();
+  clientFile.edit((s) =>
+    s.replace("Hello Client Component", "Hello [EDIT] Client Component"),
+  );
+  await page
+    .getByRole("heading", { name: "Hello [EDIT] Client Component" })
+    .click();
+  await page.getByTestId("client-component").getByText("Count: 1").click();
+
+  // server hmr
+  using serverFile = createEditor("src/routes/layout.tsx");
+  await page.getByRole("heading", { name: "Hello Server Component" }).click();
+  serverFile.edit((s) =>
+    s.replace("Hello Server Component", "Hello [EDIT] Server Component"),
+  );
+  await page
+    .getByRole("heading", { name: "Hello [EDIT] Server Component" })
+    .click();
+
+  // client component state should be preserved
+  await page
+    .getByRole("heading", { name: "Hello [EDIT] Client Component" })
+    .click();
+  await page.getByTestId("client-component").getByText("Count: 1").click();
 });
 
 test("server action 1 @js", async ({ page }) => {

--- a/examples/react-server/src/features/style/plugin.ts
+++ b/examples/react-server/src/features/style/plugin.ts
@@ -66,7 +66,7 @@ export function vitePluginServerCss({
       return collectStyle($__global.server.environments["client"], [
         ENTRY_BROWSER_BOOTSTRAP,
         // TODO: split css per-route?
-        ...manager.clientReferenceMap.values(),
+        ...manager.clientReferenceMap.keys(),
       ]);
     }),
     //

--- a/examples/react-server/src/features/style/plugin.ts
+++ b/examples/react-server/src/features/style/plugin.ts
@@ -66,7 +66,7 @@ export function vitePluginServerCss({
       return collectStyle($__global.server.environments["client"], [
         ENTRY_BROWSER_BOOTSTRAP,
         // TODO: split css per-route?
-        ...manager.clientReferenceMap.keys(),
+        ...manager.clientReferenceMap.values(),
       ]);
     }),
     //

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -226,7 +226,7 @@ function vitePluginUseClient(): PluginOption {
       }
       manager.clientReferenceMap.delete(id);
       if (code.includes("use client")) {
-        const runtimeId = await normalizeReferenceId(id, "react-server");
+        const runtimeId = await normalizeReferenceId(id, "client");
         const ast = await parseAstAsync(code);
         let output = await transformDirectiveProxyExport(ast, {
           directive: "use client",


### PR DESCRIPTION
This test is supposed to pass, but it looks like this is failing since https://github.com/hi-ogawa/vite-environment-examples/pull/97.

The difference is obvious from terminal log when changing `"use client"` files:

```
## before
3:53:16 PM [vite] (client) hmr update /src/routes/_client.tsx

## after
3:52:45 PM [vite] (client) hmr update /home/hiroshi/code/personal/vite-environment-examples/examples/react-server/src/routes/_client.tsx
```

Also note that similar "absolute path" issue is happening when testing Vite 6 in Vite 5 RSC https://github.com/hi-ogawa/vite-plugins/pull/297 even though these two use a different approach.