### PR TITLE
refactor: simplify hot update

### DIFF
--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -161,20 +161,16 @@ function vitePluginReactServer(): PluginOption {
     async configureServer(server) {
       const reactServerEnv = server.environments["react-server"];
       tinyassert(reactServerEnv);
-      const reactServerRunner = createServerModuleRunner(reactServerEnv);
+      const reactServerRunner = createServerModuleRunner(reactServerEnv, {
+        hmr: false,
+      });
       $__global.server = server;
       $__global.reactServerRunner = reactServerRunner;
     },
     hotUpdate(ctx) {
-      if (ctx.environment.name === "react-server") {
+      if (this.environment.name === "react-server") {
         const ids = ctx.modules.map((mod) => mod.id).filter(typedBoolean);
         if (ids.length > 0) {
-          const invalidated =
-            $__global.reactServerRunner.moduleCache.invalidateDepTree(ids);
-          debug("[react-server:hotUpdate]", {
-            ids,
-            invalidated: [...invalidated],
-          });
           // client reference id is also in react server module graph,
           // but we skip RSC HMR for this case since Client HMR handles it.
           if (!ids.some((id) => manager.clientReferenceMap.has(id))) {
@@ -187,10 +183,8 @@ function vitePluginReactServer(): PluginOption {
               },
             });
           }
-          return [];
         }
       }
-      return;
     },
   };
 

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -162,9 +162,8 @@ function vitePluginReactServer(): PluginOption {
     async configureServer(server) {
       const reactServerEnv = server.environments["react-server"];
       tinyassert(reactServerEnv);
-      const reactServerRunner = createServerModuleRunner(reactServerEnv, {
-        hmr: false,
-      });
+      // no hmr setup for custom node environment
+      const reactServerRunner = createServerModuleRunner(reactServerEnv);
       $__global.server = server;
       $__global.reactServerRunner = reactServerRunner;
     },

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig((_env) => ({
     vitePluginSsrMiddleware({
       entry: process.env["SERVER_ENTRY"] ?? "/src/adapters/node",
       preview: path.resolve("./dist/ssr/index.js"),
+      hmr: false,
     }),
     !!process.env["VITEST"] && vitePluginTestReactServerStream(),
   ],

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -174,7 +174,7 @@ function vitePluginReactServer(): PluginOption {
           // client reference id is also in react server module graph,
           // but we skip RSC HMR for this case since Client HMR handles it.
           if (!ids.some((id) => manager.clientReferenceMap.has(id))) {
-            console.log("[react-server:hmr]", ctx.file);
+            debug("[react-server:hmr]", ctx.file);
             $__global.server.environments.client.hot.send({
               type: "custom",
               event: "react-server:update",

--- a/packages/ssr-middleware/src/plugin.ts
+++ b/packages/ssr-middleware/src/plugin.ts
@@ -8,9 +8,11 @@ import {
 export function vitePluginSsrMiddleware({
   entry,
   preview,
+  hmr,
 }: {
   entry: string;
   preview?: string;
+  hmr?: false;
 }): PluginOption {
   const plugin: Plugin = {
     name: vitePluginSsrMiddleware.name,
@@ -33,7 +35,10 @@ export function vitePluginSsrMiddleware({
     },
 
     configureServer(server) {
-      const runner = createServerModuleRunner(server.environments.ssr);
+      const runner = createServerModuleRunner(
+        server.environments.ssr,
+        hmr === false ? { hmr: false } : undefined,
+      );
 
       const handler: Connect.NextHandleFunction = async (req, res, next) => {
         try {


### PR DESCRIPTION
`invalidateDepTree` is redundant since that's the default non hmr invalidation behavior.