### PR TITLE
feat: add web-worker example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - run: pnpm -C examples/react-ssr-workerd test-e2e
       - run: pnpm -C examples/workerd-cli test
       - run: pnpm -C examples/browser-cli test
+      - run: pnpm -C examples/web-worker test-e2e
       - run: pnpm -C examples/react-server test-e2e
       - run: pnpm -C examples/react-server build
       - run: pnpm -C examples/react-server test-e2e-preview

--- a/examples/browser-cli/README.md
+++ b/examples/browser-cli/README.md
@@ -1,12 +1,11 @@
 # browser-cli
 
 ```sh
+# use CLI_HEADED=1 to show browser window
 $ pnpm cli
 > window.navigator.userAgent
 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/127.0.6533.17 Safari/537.36
-> self.ReactDom = await import("react-dom");;
-undefined
-> ReactDom.render(<div>yay</div>, document.body)
+> (await import("react-dom")).render(<div>yay</div>, document.body)
 ref: <Node>
 > document.body.innerHTML
 <div>yay</div>

--- a/examples/web-worker/README.md
+++ b/examples/web-worker/README.md
@@ -5,3 +5,7 @@ pnpm dev
 pnpm build
 pnpm preview
 ```
+
+## related
+
+- https://github.com/vitejs/vite/discussions/18191

--- a/examples/web-worker/README.md
+++ b/examples/web-worker/README.md
@@ -1,0 +1,7 @@
+# web-worker
+
+```sh
+pnpm dev
+pnpm build
+pnpm preview
+```

--- a/examples/web-worker/README.md
+++ b/examples/web-worker/README.md
@@ -2,10 +2,9 @@
 
 ```sh
 pnpm dev
-pnpm build
-pnpm preview
 ```
 
 ## related
 
 - https://github.com/vitejs/vite/discussions/18191
+- https://github.com/vitejs/vite/issues/7439

--- a/examples/web-worker/e2e/basic.test.ts
+++ b/examples/web-worker/e2e/basic.test.ts
@@ -2,8 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test("basic", async ({ page }) => {
   await page.goto("/");
-  await expect(page.locator("#root")).toContainText("hydrated: true");
-  await expect(page.locator("#root")).toContainText("Count: 0");
-  await page.getByRole("button", { name: "+" }).click();
-  await expect(page.locator("#root")).toContainText("Count: 1");
+  await expect(page.getByTestId("worker-message")).toContainText(
+    "Rendered in web worker",
+  );
 });

--- a/examples/web-worker/e2e/basic.test.ts
+++ b/examples/web-worker/e2e/basic.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "@playwright/test";
+
+test("basic", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("#root")).toContainText("hydrated: true");
+  await expect(page.locator("#root")).toContainText("Count: 0");
+  await page.getByRole("button", { name: "+" }).click();
+  await expect(page.locator("#root")).toContainText("Count: 1");
+});

--- a/examples/web-worker/index.html
+++ b/examples/web-worker/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Worker</title>
+    <meta
+      name="viewport"
+      content="width=device-width, height=device-height, initial-scale=1.0"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="/src/entry-client" type="module"></script>
+  </body>
+</html>

--- a/examples/web-worker/package.json
+++ b/examples/web-worker/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@hiogawa/vite-environment-examples-web-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build --app",
+    "preview": "vite preview",
+    "test-e2e": "playwright test",
+    "test-e2e-preview": "E2E_PREVIEW=1 playwright test"
+  },
+  "dependencies": {
+    "react": "19.0.0-rc-eb3ad065-20240822",
+    "react-dom": "19.0.0-rc-eb3ad065-20240822"
+  },
+  "devDependencies": {
+    "@hiogawa/vite-plugin-ssr-middleware-alpha": "workspace:*",
+    "@hiogawa/vite-plugin-workerd": "workspace:*",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/examples/web-worker/playwright.config.ts
+++ b/examples/web-worker/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env["E2E_PORT"] || 6174);
+const command = process.env["E2E_PREVIEW"]
+  ? `pnpm preview --port ${port} --strict-port`
+  : `pnpm dev --port ${port} --strict-port`;
+
+export default defineConfig({
+  testDir: "e2e",
+  use: {
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: devices["Desktop Chrome"],
+    },
+  ],
+  webServer: {
+    command,
+    port,
+  },
+  forbidOnly: !!process.env["CI"],
+  retries: process.env["CI"] ? 2 : 0,
+  reporter: "list",
+});

--- a/examples/web-worker/src/app.tsx
+++ b/examples/web-worker/src/app.tsx
@@ -24,7 +24,10 @@ export function App() {
       <button onClick={() => setCount((c) => c - 1)}>-1</button>
       <button onClick={() => setCount((c) => c + 1)}>+1</button>
       <hr />
-      <div dangerouslySetInnerHTML={{ __html: workerMessage }}></div>
+      <div
+        data-testid="worker-message"
+        dangerouslySetInnerHTML={{ __html: workerMessage }}
+      ></div>
     </div>
   );
 }

--- a/examples/web-worker/src/app.tsx
+++ b/examples/web-worker/src/app.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import workerUrl from "./entry-worker?worker-runner";
+import workerUrl from "./worker/entry?worker-runner";
 
 export function App() {
   const [count, setCount] = React.useState(0);

--- a/examples/web-worker/src/app.tsx
+++ b/examples/web-worker/src/app.tsx
@@ -3,19 +3,28 @@ import workerUrl from "./entry-worker?worker-runner";
 
 export function App() {
   const [count, setCount] = React.useState(0);
+  const [workerMessage, setWorkerMessage] = React.useState(
+    "Waiting for worker...",
+  );
 
   React.useEffect(() => {
     const worker = new Worker(workerUrl, { type: "module" });
+    worker.addEventListener("message", (e) => {
+      setWorkerMessage(e.data);
+    });
+    worker.postMessage("ping");
     return () => {
       worker.terminate();
     };
-  });
+  }, []);
 
   return (
     <div>
       <div>Count: {count}</div>
       <button onClick={() => setCount((c) => c - 1)}>-1</button>
       <button onClick={() => setCount((c) => c + 1)}>+1</button>
+      <hr />
+      <div dangerouslySetInnerHTML={{ __html: workerMessage }}></div>
     </div>
   );
 }

--- a/examples/web-worker/src/app.tsx
+++ b/examples/web-worker/src/app.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export function App() {
+  const [count, setCount] = React.useState(0);
+  return (
+    <div>
+      <div>Count: {count}</div>
+      <button onClick={() => setCount((c) => c - 1)}>-1</button>
+      <button onClick={() => setCount((c) => c + 1)}>+1</button>
+    </div>
+  );
+}

--- a/examples/web-worker/src/app.tsx
+++ b/examples/web-worker/src/app.tsx
@@ -1,7 +1,16 @@
 import React from "react";
+import workerUrl from "./entry-worker?worker-runner";
 
 export function App() {
   const [count, setCount] = React.useState(0);
+
+  React.useEffect(() => {
+    const worker = new Worker(workerUrl, { type: "module" });
+    return () => {
+      worker.terminate();
+    };
+  });
+
   return (
     <div>
       <div>Count: {count}</div>

--- a/examples/web-worker/src/entry-client.tsx
+++ b/examples/web-worker/src/entry-client.tsx
@@ -1,0 +1,9 @@
+import ReactDomClient from "react-dom/client";
+import { App } from "./app";
+
+async function main() {
+  const el = document.getElementById("root");
+  ReactDomClient.createRoot(el!).render(<App />);
+}
+
+main();

--- a/examples/web-worker/src/entry-worker.tsx
+++ b/examples/web-worker/src/entry-worker.tsx
@@ -1,4 +1,0 @@
-import ReactDomServer from "react-dom/server";
-
-const result = ReactDomServer.renderToString(<div>Rendered in web worker</div>);
-self.postMessage(result);

--- a/examples/web-worker/src/entry-worker.tsx
+++ b/examples/web-worker/src/entry-worker.tsx
@@ -1,0 +1,1 @@
+console.log("hi worker");

--- a/examples/web-worker/src/entry-worker.tsx
+++ b/examples/web-worker/src/entry-worker.tsx
@@ -1,1 +1,4 @@
-console.log("hi worker");
+import ReactDomServer from "react-dom/server";
+
+const result = ReactDomServer.renderToString(<div>Rendered in web worker</div>);
+self.postMessage(result);

--- a/examples/web-worker/src/lib/ambient.d.ts
+++ b/examples/web-worker/src/lib/ambient.d.ts
@@ -1,0 +1,4 @@
+declare module "*?worker-runner" {
+  const src: string;
+  export default src;
+}

--- a/examples/web-worker/src/lib/fetch-module-client.ts
+++ b/examples/web-worker/src/lib/fetch-module-client.ts
@@ -1,0 +1,12 @@
+import type { FetchFunction } from "vite";
+
+export function fetchClientFetchModule(environmentName: string): FetchFunction {
+  return async (...args) => {
+    const payload = JSON.stringify([environmentName, ...args]);
+    const response = await fetch(
+      "/@vite/fetchModule?" + new URLSearchParams({ payload }),
+    );
+    const result = response.json();
+    return result as any;
+  };
+}

--- a/examples/web-worker/src/lib/fetch-module-server.ts
+++ b/examples/web-worker/src/lib/fetch-module-server.ts
@@ -1,0 +1,21 @@
+import type { FetchFunction, Plugin } from "vite";
+
+export function vitePluginFetchModuleServer(): Plugin {
+  return {
+    name: vitePluginFetchModuleServer.name,
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        const url = new URL(req.url ?? "/", "https://any.local");
+        if (url.pathname === "/@vite/fetchModule") {
+          const [name, ...args] = JSON.parse(url.searchParams.get("payload")!);
+          const result = await server.environments[name]!.fetchModule(
+            ...(args as Parameters<FetchFunction>),
+          );
+          res.end(JSON.stringify(result));
+          return;
+        }
+        next();
+      });
+    },
+  };
+}

--- a/examples/web-worker/src/lib/runner.ts
+++ b/examples/web-worker/src/lib/runner.ts
@@ -1,0 +1,20 @@
+import { ESModulesEvaluator, ModuleRunner } from "vite/module-runner";
+import { fetchClientFetchModule } from "./fetch-module-client";
+
+export function createFetchRunner(options: {
+  root: string;
+  environmentName: string;
+}) {
+  const runner = new ModuleRunner(
+    {
+      root: options.root,
+      sourcemapInterceptor: false,
+      transport: {
+        fetchModule: fetchClientFetchModule(options.environmentName),
+      },
+      hmr: false,
+    },
+    new ESModulesEvaluator(),
+  );
+  return runner;
+}

--- a/examples/web-worker/src/worker/dep.tsx
+++ b/examples/web-worker/src/worker/dep.tsx
@@ -1,0 +1,1 @@
+export default "dep-ok";

--- a/examples/web-worker/src/worker/entry.tsx
+++ b/examples/web-worker/src/worker/entry.tsx
@@ -1,0 +1,12 @@
+import ReactDomServer from "react-dom/server";
+import dep from "./dep";
+
+const root = (
+  <div>
+    <div>Rendered in web worker</div>
+    <div>{dep}</div>
+  </div>
+);
+
+const result = ReactDomServer.renderToString(root);
+self.postMessage(result);

--- a/examples/web-worker/tsconfig.json
+++ b/examples/web-worker/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "@tsconfig/strictest/tsconfig.json",
-  "include": [
-    "src",
-    "vite.config.ts",
-    "vite.config.workerd.ts",
-    "e2e",
-    "playwright.config.ts"
-  ],
+  "include": ["src", "e2e", "*.ts"],
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
     "verbatimModuleSyntax": true,

--- a/examples/web-worker/tsconfig.json
+++ b/examples/web-worker/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "@tsconfig/strictest/tsconfig.json",
+  "include": [
+    "src",
+    "vite.config.ts",
+    "vite.config.workerd.ts",
+    "e2e",
+    "playwright.config.ts"
+  ],
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "types": ["vite/client"],
+    "jsx": "react-jsx"
+  }
+}

--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -12,11 +12,6 @@ export default defineConfig((_env) => ({
           exclude: ["vite/module-runner"],
         },
       },
-      build: {
-        minify: false,
-        sourcemap: true,
-        outDir: "dist/client",
-      },
     },
     worker: {
       webCompatible: true,
@@ -34,20 +29,6 @@ export default defineConfig((_env) => ({
           ],
         },
       },
-      build: {
-        outDir: "dist/worker",
-        rollupOptions: {
-          input: {
-            index: "/src/entry-worker",
-          },
-        },
-      },
-    },
-  },
-
-  builder: {
-    async buildApp(builder) {
-      await builder.build(builder.environments["client"]!);
     },
   },
 }));

--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -19,7 +19,21 @@ export default defineConfig((_env) => ({
       },
     },
     worker: {
-      resolve: {},
+      webCompatible: true,
+      resolve: {
+        conditions: ["worker"],
+        noExternal: true,
+      },
+      dev: {
+        optimizeDeps: {
+          include: [
+            "react",
+            "react/jsx-runtime",
+            "react/jsx-dev-runtime",
+            "react-dom/server",
+          ],
+        },
+      },
       build: {
         outDir: "dist/worker",
         rollupOptions: {

--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -1,0 +1,37 @@
+import react from "@vitejs/plugin-react";
+import { type Plugin, defineConfig } from "vite";
+
+export default defineConfig((_env) => ({
+  clearScreen: false,
+  plugins: [react(), vitePluginWebWorkerEnvironment()],
+  environments: {
+    client: {
+      build: {
+        minify: false,
+        sourcemap: true,
+        outDir: "dist/client",
+      },
+    },
+    worker: {
+      resolve: {},
+      build: {
+        outDir: "dist/worker",
+        rollupOptions: {
+          input: {
+            index: "/src/entry-worker",
+          },
+        },
+      },
+    },
+  },
+
+  builder: {
+    async buildApp(builder) {
+      await builder.build(builder.environments["client"]!);
+    },
+  },
+}));
+
+function vitePluginWebWorkerEnvironment(): Plugin[] {
+  return [];
+}

--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -1,11 +1,17 @@
 import react from "@vitejs/plugin-react";
 import { type Plugin, defineConfig } from "vite";
+import { vitePluginFetchModuleServer } from "./src/lib/fetch-module-server";
 
 export default defineConfig((_env) => ({
   clearScreen: false,
-  plugins: [react(), vitePluginWebWorkerEnvironment()],
+  plugins: [react(), vitePluginWorkerRunner(), vitePluginFetchModuleServer()],
   environments: {
     client: {
+      dev: {
+        optimizeDeps: {
+          exclude: ["vite/module-runner"],
+        },
+      },
       build: {
         minify: false,
         sourcemap: true,
@@ -32,6 +38,38 @@ export default defineConfig((_env) => ({
   },
 }));
 
-function vitePluginWebWorkerEnvironment(): Plugin[] {
-  return [];
+function vitePluginWorkerRunner(): Plugin[] {
+  const workerEntryPlugin: Plugin = {
+    name: vitePluginWorkerRunner.name + ":entry",
+    transform(_code, id) {
+      // rewrite ?worker-runner import
+      if (id.endsWith("?worker-runner")) {
+        const workerUrl = id.replace("?worker-runner", "?worker-runner-file");
+        return `export default ${JSON.stringify(workerUrl)}`;
+      }
+
+      // rewrite worker entry to execute it on runner
+      if (id.endsWith("?worker-runner-file")) {
+        const options = {
+          root: this.environment.config.root,
+          environmentName: "worker",
+        };
+        const entryId = id.replace("?worker-runner-file", "");
+        const output = `
+          import { createFetchRunner } from "/src/lib/runner";
+          const runner = createFetchRunner(${JSON.stringify(options)});
+          runner.import(${JSON.stringify(entryId)});
+        `;
+        return { code: output };
+      }
+      return;
+    },
+    hotUpdate(ctx) {
+      if (this.environment.name === "worker" && ctx.modules.length > 0) {
+        this.environment;
+      }
+    },
+  };
+
+  return [workerEntryPlugin];
 }

--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -62,7 +62,7 @@ function vitePluginWorkerRunner(): Plugin[] {
         return `export default ${JSON.stringify(workerUrl)}`;
       }
 
-      // rewrite worker entry to execute it on runner
+      // rewrite worker entry to import it from runner
       if (id.endsWith("?worker-runner-file")) {
         const options = {
           root: this.environment.config.root,

--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -79,8 +79,9 @@ function vitePluginWorkerRunner(): Plugin[] {
       return;
     },
     hotUpdate(ctx) {
+      // full reload browser on worker code change
       if (this.environment.name === "worker" && ctx.modules.length > 0) {
-        this.environment;
+        ctx.server.ws.send({ type: "full-reload", path: ctx.file });
       }
     },
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,28 @@ importers:
         specifier: ^2.0.26
         version: 2.0.26(typescript@5.5.3)
 
+  examples/web-worker:
+    dependencies:
+      react:
+        specifier: 19.0.0-rc-eb3ad065-20240822
+        version: 19.0.0-rc-eb3ad065-20240822
+      react-dom:
+        specifier: 19.0.0-rc-eb3ad065-20240822
+        version: 19.0.0-rc-eb3ad065-20240822(react@19.0.0-rc-eb3ad065-20240822)
+    devDependencies:
+      '@hiogawa/vite-plugin-ssr-middleware-alpha':
+        specifier: workspace:*
+        version: link:../../packages/ssr-middleware
+      '@hiogawa/vite-plugin-workerd':
+        specifier: workspace:*
+        version: link:../../packages/workerd
+      '@types/react':
+        specifier: 18.3.3
+        version: 18.3.3
+      '@types/react-dom':
+        specifier: 18.3.0
+        version: 18.3.0
+
   examples/workerd-cli:
     devDependencies:
       '@hiogawa/vite-plugin-workerd':


### PR DESCRIPTION
Experiment https://github.com/users/hi-ogawa/projects/4/views/1?pane=issue&itemId=80967865

## todo

- [x] reload browser on worker `hotUpdate`
- [x] test
- [ ] demo
  - [x] render in worker
  - [ ] rsc in web worker?
- [ ] solve https://github.com/vitejs/vite/issues/7439
- [ ] what to do with build?
  - need `worker -> client` build ordering
  - but need `client` build first to discover worker entries
  - replace during `renderChunk`?

## feedback

- [ ] `environment.webCompatible` should be included in optimizer hash