### PR TITLE
feat: web-worker environment build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - run: pnpm -C examples/workerd-cli test
       - run: pnpm -C examples/browser-cli test
       - run: pnpm -C examples/web-worker test-e2e
+      - run: pnpm -C examples/web-worker build
+      - run: pnpm -C examples/web-worker test-e2e-preview
       - run: pnpm -C examples/web-worker-rsc test-e2e
       - run: pnpm -C examples/react-server test-e2e
       - run: pnpm -C examples/react-server build

--- a/examples/web-worker/README.md
+++ b/examples/web-worker/README.md
@@ -2,6 +2,8 @@
 
 ```sh
 pnpm dev
+pnpm build
+pnpm preview
 ```
 
 ## related

--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig((_env) => ({
           exclude: ["vite/module-runner"],
         },
       },
+      build: {
+        outDir: "dist/client",
+        minify: false,
+      },
     },
     worker: {
       webCompatible: true,
@@ -29,6 +33,19 @@ export default defineConfig((_env) => ({
           ],
         },
       },
+      build: {
+        outDir: "dist/worker",
+        minify: false,
+        ssr: true,
+      },
+    },
+  },
+
+  builder: {
+    async buildApp(builder) {
+      // TODO
+      await builder.build(builder.environments["client"]!);
+      // await builder.build(builder.environments["worker"]!);
     },
   },
 }));

--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -36,7 +36,12 @@ export default defineConfig((_env) => ({
       build: {
         outDir: "dist/worker",
         minify: false,
-        ssr: true,
+        modulePreload: false,
+        rollupOptions: {
+          input: {
+            unused: `data:text/javascript,console.log("unused")`,
+          },
+        },
       },
     },
   },
@@ -45,7 +50,7 @@ export default defineConfig((_env) => ({
     async buildApp(builder) {
       // TODO
       await builder.build(builder.environments["client"]!);
-      // await builder.build(builder.environments["worker"]!);
+      await builder.build(builder.environments["worker"]!);
     },
   },
 }));


### PR DESCRIPTION
- follow up to https://github.com/hi-ogawa/vite-environment-examples/pull/113

Probably this requires something similar to how we discover client/server references in rsc:
- https://github.com/hi-ogawa/vite-environment-examples/blob/cf6de72ab481e5e70f24b8c1f9e493e8c877bca1/examples/react-server/vite.config.ts#L89-L94
- https://github.com/hi-ogawa/vite-plugins/pull/350


## todo

- [x] worker in client
- [x] worker in worker https://github.com/hi-ogawa/vite-environment-examples/pull/119
- [ ] parallel build
