### PR TITLE
refactor: simplify "worker in worker" build

### DIFF
--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -102,13 +102,17 @@ export function vitePluginWorkerEnvironment(): Plugin[] {
           if (manager.workerScan) {
             // client -> worker (scan)
             manager.workerMap[entry] = {};
-            // import worker as is to collect worker in worker during scan
-            code = `
-              import ${JSON.stringify(entry)};
-              export default "noop";
-            `;
+            code = `export default "__unused"`;
           } else if (this.environment.name === "worker") {
             // worker -> worker (build)
+            if (!(entry in manager.workerMap)) {
+              manager.workerMap[entry] = {
+                referenceId: this.emitFile({
+                  type: "chunk",
+                  id,
+                }),
+              };
+            }
             const referenceId = manager.workerMap[entry]!.referenceId;
             code = `export default import.meta.ROLLUP_FILE_URL_${referenceId}`;
           } else if (this.environment.name === "client") {

--- a/examples/web-worker/vite.config.ts
+++ b/examples/web-worker/vite.config.ts
@@ -109,7 +109,7 @@ export function vitePluginWorkerEnvironment(): Plugin[] {
               manager.workerMap[entry] = {
                 referenceId: this.emitFile({
                   type: "chunk",
-                  id,
+                  id: entry,
                 }),
               };
             }

--- a/misc/vite-ecosystem-ci.sh
+++ b/misc/vite-ecosystem-ci.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -eu -o pipefail
 
+# web worker environment
+pnpm -C examples/web-worker test-e2e
+pnpm -C examples/web-worker build
+pnpm -C examples/web-worker test-e2e-preview
+
 # workerd environment
 pnpm -C examples/react-ssr-workerd test-e2e
 


### PR DESCRIPTION
Passing through "client -> worker" import for scanning shouldn't be necessary since we can `emitFile` on the fly during `transform`.