### PR TITLE
feat: client/worker parallel build

### DIFF
--- a/examples/web-worker/README.md
+++ b/examples/web-worker/README.md
@@ -39,10 +39,12 @@ runner.import("/path-to/worker.ts");
 
 __transform during build__
 
-Plugin ensures a following build steps to handle client's worker import:
+This plugin orchestrates a following build steps:
 
 - client `buildEnd` kicks off worker `buildStart`
-- worker `generateBundle` kicks off client `renderChunk`
+  - worker build starts with `emitFile` of worker references from client.
+- worker `generateBundle` kicks off client `renderChunk`:
+  - `__VITE_WORKER_URL_PLACEHOLDER["<entry>"]` inside client chunk is replaced with actual worker build's output url.
 
 ```ts
 //// transform of /path-to/worker.ts?worker-env

--- a/examples/web-worker/README.md
+++ b/examples/web-worker/README.md
@@ -23,7 +23,7 @@ import workerUrl from "./worker.ts?worker-env";
 const worker = new Worker(workerUrl, { type: "module" });
 ```
 
-__transform during dev__
+__Transform during dev__
 
 ```ts
 //// transform of /path-to/worker.ts?worker-env
@@ -37,7 +37,7 @@ const runner = createFetchRunner({ root: "...", environmentName: "worker" });
 runner.import("/path-to/worker.ts");
 ```
 
-__transform during build__
+__Transform during build__
 
 This plugin orchestrates a following build steps:
 
@@ -51,9 +51,9 @@ This plugin orchestrates a following build steps:
 export default "/path-to-emitted-chunk/worker-xxyyzzww.js";
 ```
 
-## TBD
+## TODO
 
-- only esm supports multi worker entries
+- only esm can support multi worker entries. what to do with iife?
 - optimizeDeps
 - hmr
 - resolve conditions bug https://github.com/vitejs/vite/issues/18222

--- a/examples/web-worker/README.md
+++ b/examples/web-worker/README.md
@@ -39,11 +39,10 @@ runner.import("/path-to/worker.ts");
 
 __transform during build__
 
-Build pipeline (notably it requires building client twice):
+Plugin ensures a following build steps to handle client's worker import:
 
-- 1st client build: discover `./worker.ts?worker-env` imports,
-- worker build: `emitFile({ type: "chunk", id: "/path-to/worker.ts" })` for discovered `?worker-env` imports,
-- 2nd client build: transform `./worker.ts?worker-env` using worker build chunks,
+- client `buildEnd` kicks off worker `buildStart`
+- worker `generateBundle` kicks off client `renderChunk`
 
 ```ts
 //// transform of /path-to/worker.ts?worker-env
@@ -52,7 +51,6 @@ export default "/path-to-emitted-chunk/worker-xxyyzzww.js";
 
 ## TBD
 
-- need parallel client/worker build to avoid extra client build for discovering worker references
 - only esm supports multi worker entries
 - optimizeDeps
 - hmr

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "esbuild": "^0.23.0",
+    "magic-string": "^0.30.10",
     "miniflare": "^3.20240909.5",
     "react": "19.0.0-rc-eb3ad065-20240822",
     "react-dom": "19.0.0-rc-eb3ad065-20240822",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       esbuild:
         specifier: ^0.23.0
         version: 0.23.0
+      magic-string:
+        specifier: ^0.30.10
+        version: 0.30.10
       miniflare:
         specifier: ^3.20240909.5
         version: 3.20240909.5


### PR DESCRIPTION
- follow up to https://github.com/hi-ogawa/vite-environment-examples/pull/118

## todo

- [x] replace worker reference during `renderChunk`
- [x] update readme