### PR TITLE
fix:  update environment name for allowed characters

### DIFF
--- a/examples/react-server/src/features/style/plugin.ts
+++ b/examples/react-server/src/features/style/plugin.ts
@@ -75,7 +75,7 @@ export function vitePluginServerCss({
     createVirtualPlugin(VIRTUAL_COPY_SERVER_CSS.slice(8), async () => {
       if ($__global.server) {
         const urls = await collectStyleUrls(
-          $__global.server.environments["react-server"],
+          $__global.server.environments["rsc"],
           // TODO: lazy import is not crawled until it's imported
           ["/src/entry-server"],
         );

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -129,7 +129,7 @@ function vitePluginReactServer(): PluginOption {
       tinyassert(config.environments);
       config.environments["rsc"] = {
         resolve: {
-          conditions: ["rsc"],
+          conditions: ["react-server"],
           noExternal: true,
         },
         dev: {

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -90,10 +90,10 @@ export default defineConfig((_env) => ({
       // by traversing server module graph and going over client boundary
       // TODO: this causes single plugin to be reused by two react-server builds
       manager.buildStep = "scan";
-      await builder.build(builder.environments["react-server"]!);
+      await builder.build(builder.environments["rsc"]!);
       manager.buildStep = undefined;
 
-      await builder.build(builder.environments["react-server"]!);
+      await builder.build(builder.environments["rsc"]!);
       await builder.build(builder.environments["client"]!);
       await builder.build(builder.environments["ssr"]!);
     },
@@ -127,9 +127,9 @@ function vitePluginReactServer(): PluginOption {
     name: vitePluginReactServer.name,
     config(config, _env) {
       tinyassert(config.environments);
-      config.environments["react-server"] = {
+      config.environments["rsc"] = {
         resolve: {
-          conditions: ["react-server"],
+          conditions: ["rsc"],
           noExternal: true,
         },
         dev: {
@@ -160,7 +160,7 @@ function vitePluginReactServer(): PluginOption {
       manager.config = config;
     },
     async configureServer(server) {
-      const reactServerEnv = server.environments["react-server"];
+      const reactServerEnv = server.environments["rsc"];
       tinyassert(reactServerEnv);
       // no hmr setup for custom node environment
       const reactServerRunner = createServerModuleRunner(reactServerEnv);
@@ -168,7 +168,7 @@ function vitePluginReactServer(): PluginOption {
       $__global.reactServerRunner = reactServerRunner;
     },
     hotUpdate(ctx) {
-      if (this.environment.name === "react-server") {
+      if (this.environment.name === "rsc") {
         const ids = ctx.modules.map((mod) => mod.id).filter(typedBoolean);
         if (ids.length > 0) {
           // client reference id is also in react server module graph,
@@ -215,7 +215,7 @@ function vitePluginUseClient(): PluginOption {
   const transformPlugin: Plugin = {
     name: vitePluginUseClient.name + ":transform",
     async transform(code, id, _options) {
-      if (this.environment.name !== "react-server") {
+      if (this.environment.name !== "rsc") {
         return;
       }
       manager.clientReferenceMap.delete(id);
@@ -254,7 +254,7 @@ function vitePluginUseClient(): PluginOption {
   const virtualPlugin: Plugin = createVirtualPlugin(
     "client-references",
     function () {
-      tinyassert(this.environment?.name !== "react-server");
+      tinyassert(this.environment?.name !== "rsc");
       tinyassert(this.environment?.mode === "build");
 
       return [
@@ -297,8 +297,8 @@ function vitePluginServerAction(): PluginOption {
       }
       const ast = await parseAstAsync(code);
       tinyassert(this.environment);
-      const runtimeId = await normalizeReferenceId(id, "react-server");
-      if (this.environment.name === "react-server") {
+      const runtimeId = await normalizeReferenceId(id, "rsc");
+      if (this.environment.name === "rsc") {
         const { output } = await transformServerActionServer(code, ast, {
           id: runtimeId,
           runtime: "$$register",
@@ -345,7 +345,7 @@ function vitePluginServerAction(): PluginOption {
       if (manager.buildStep === "scan") {
         return `export default {}`;
       }
-      tinyassert(this.environment?.name === "react-server");
+      tinyassert(this.environment?.name === "rsc");
       tinyassert(this.environment.mode === "build");
       return [
         "export default {",
@@ -361,7 +361,7 @@ function vitePluginServerAction(): PluginOption {
     name: "patch-react-server-dom-webpack",
     transform(code, id, _options) {
       if (
-        this.environment?.name === "react-server" &&
+        this.environment?.name === "rsc" &&
         id.includes("react-server-dom-webpack")
       ) {
         // rename webpack markers in react server runtime
@@ -389,10 +389,7 @@ function vitePluginServerAction(): PluginOption {
   return [transformPlugin, virtualServerReference, patchPlugin];
 }
 
-async function normalizeReferenceId(
-  id: string,
-  name: "client" | "react-server",
-) {
+async function normalizeReferenceId(id: string, name: "client" | "rsc") {
   if (manager.config.command === "build") {
     return hashString(path.relative(manager.config.root, id));
   }
@@ -411,7 +408,7 @@ async function normalizeReferenceId(
       runtimeId = m?.[1];
       break;
     }
-    case "react-server": {
+    case "rsc": {
       // `dynamicDeps` is available for ssrTransform
       runtimeId = transformed.dynamicDeps?.[0];
       break;

--- a/examples/web-worker-rsc/vite.config.ts
+++ b/examples/web-worker-rsc/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig((_env) => ({
     worker: {
       webCompatible: true,
       resolve: {
-        conditions: ["rsc"],
+        conditions: ["react-server"],
         noExternal: true,
       },
       dev: {

--- a/examples/web-worker-rsc/vite.config.ts
+++ b/examples/web-worker-rsc/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig((_env) => ({
     worker: {
       webCompatible: true,
       resolve: {
-        conditions: ["react-server"],
+        conditions: ["rsc"],
         noExternal: true,
       },
       dev: {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tsup": "^8.1.2",
     "tsx": "^4.16.2",
     "typescript": "^5.5.3",
-    "vite": "6.0.0-beta.2",
+    "vite": "https://pkg.pr.new/vite@87949fe",
     "vitest": "^2.0.3",
     "wrangler": "^3.79.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: 6.0.0-beta.2
+  vite: https://pkg.pr.new/vite@87949fe
 
 importers:
 
@@ -22,7 +22,7 @@ importers:
         version: 0.0.2
       '@hiogawa/vite-plugin-ssr-middleware':
         specifier: ^0.0.3
-        version: 0.0.3(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))
+        version: 0.0.3(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))
       '@playwright/test':
         specifier: ^1.45.2
         version: 1.45.2
@@ -40,7 +40,7 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.1(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))
+        version: 4.3.1(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))
       esbuild:
         specifier: ^0.23.0
         version: 0.23.0
@@ -69,8 +69,8 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       vite:
-        specifier: 6.0.0-beta.2
-        version: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+        specifier: https://pkg.pr.new/vite@87949fe
+        version: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
       vitest:
         specifier: ^2.0.3
         version: 2.0.3(@types/node@20.14.11)(happy-dom@14.12.3)(terser@5.31.3)
@@ -99,7 +99,7 @@ importers:
         version: 0.30.10
       unocss:
         specifier: 0.61.5
-        version: 0.61.5(postcss@8.4.47)(rollup@4.23.0)(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))
+        version: 0.61.5(postcss@8.4.47)(rollup@4.23.0)(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))
 
   examples/react-ssr:
     devDependencies:
@@ -133,7 +133,7 @@ importers:
         version: link:../../packages/workerd
       '@vitejs/plugin-vue':
         specifier: ^5.0.5
-        version: 5.0.5(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))
+        version: 5.0.5(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))
       vue-tsc:
         specifier: ^2.0.26
         version: 2.0.26(typescript@5.5.3)
@@ -158,7 +158,7 @@ importers:
         version: link:../../packages/workerd
       '@vitejs/plugin-vue':
         specifier: ^5.0.5
-        version: 5.0.5(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))
+        version: 5.0.5(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))
       vue-tsc:
         specifier: ^2.0.26
         version: 2.0.26(typescript@5.5.3)
@@ -176,8 +176,8 @@ importers:
   packages/ssr-middleware:
     dependencies:
       vite:
-        specifier: 6.0.0-beta.2
-        version: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+        specifier: https://pkg.pr.new/vite@87949fe
+        version: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
 
   packages/workerd:
     devDependencies:
@@ -188,8 +188,8 @@ importers:
         specifier: ^3.20240925.0
         version: 3.20240925.0
       vite:
-        specifier: 6.0.0-beta.2
-        version: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+        specifier: https://pkg.pr.new/vite@87949fe
+        version: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
       wrangler:
         specifier: ^3.79.0
         version: 3.79.0(@cloudflare/workers-types@4.20240925.0)
@@ -1048,8 +1048,9 @@ packages:
 
   '@hiogawa/vite-plugin-ssr-middleware@0.0.3':
     resolution: {integrity: sha512-84bzaAuImty4s4vHjOk5MQMzmDs0W0GP43fOTFhsBfj/MSJCNJ68elmPNZWs57WkIEzcdB4haY/P8Nf4ZGH8Qw==}
+    version: 0.0.3
     peerDependencies:
-      vite: 6.0.0-beta.2
+      vite: https://pkg.pr.new/vite@87949fe
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -1325,8 +1326,9 @@ packages:
 
   '@unocss/astro@0.61.5':
     resolution: {integrity: sha512-keyh6/EsPMBEiLguaOsh47UcMkWCGT0rW3KV5aYRUfYXlgccSzDd4SLmTNsdlGXIso2XCl/14BJQuwjP0UEU0Q==}
+    version: 0.61.5
     peerDependencies:
-      vite: 6.0.0-beta.2
+      vite: https://pkg.pr.new/vite@87949fe
     peerDependenciesMeta:
       vite:
         optional: true
@@ -1406,20 +1408,23 @@ packages:
 
   '@unocss/vite@0.61.5':
     resolution: {integrity: sha512-+U5Ey5Z2csjLy7zcaDCtUqs08+ugRK87UWGm65W8yMAGW7me72f36QR8IHJUTqlVVEdhbJVIAy+yNFjGHYffjA==}
+    version: 0.61.5
     peerDependencies:
-      vite: 6.0.0-beta.2
+      vite: https://pkg.pr.new/vite@87949fe
 
   '@vitejs/plugin-react@4.3.1':
     resolution: {integrity: sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg==}
+    version: 4.3.1
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: 6.0.0-beta.2
+      vite: https://pkg.pr.new/vite@87949fe
 
   '@vitejs/plugin-vue@5.0.5':
     resolution: {integrity: sha512-LOjm7XeIimLBZyzinBQ6OSm3UBCNVCpLkxGC0oWmm2YPzVZoxMsdvNVimLTBzpAnR9hl/yn1SHGuRfe6/Td9rQ==}
+    version: 5.0.5
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: 6.0.0-beta.2
+      vite: https://pkg.pr.new/vite@87949fe
       vue: ^3.2.25
 
   '@vitest/expect@2.0.3':
@@ -2639,10 +2644,11 @@ packages:
 
   unocss@0.61.5:
     resolution: {integrity: sha512-BScwlqXW9KHQLKIKtXmwWmMb4Ihoryb7uIgmS+HSqmCN58eqNA73vAo3cZ97xtO+RFdauqgGKP5wD6ShQUvqnQ==}
+    version: 0.61.5
     engines: {node: '>=14'}
     peerDependencies:
       '@unocss/webpack': 0.61.5
-      vite: 6.0.0-beta.2
+      vite: https://pkg.pr.new/vite@87949fe
     peerDependenciesMeta:
       '@unocss/webpack':
         optional: true
@@ -2663,8 +2669,9 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite@6.0.0-beta.2:
-    resolution: {integrity: sha512-TdrjEhCnVNjT3kjohFhVJQL9V3SguxMAphP2RW085QbE0Xc+lRvql9l5hTIr/mttO2jhivYXEP4xfaIRPjzqiw==}
+  vite@https://pkg.pr.new/vite@87949fe:
+    resolution: {tarball: https://pkg.pr.new/vite@87949fe}
+    version: 6.0.0-beta.2
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -3462,9 +3469,9 @@ snapshots:
 
   '@hiogawa/utils@1.7.0': {}
 
-  '@hiogawa/vite-plugin-ssr-middleware@0.0.3(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))':
+  '@hiogawa/vite-plugin-ssr-middleware@0.0.3(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))':
     dependencies:
-      vite: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
 
   '@iconify/types@2.0.0': {}
 
@@ -3699,13 +3706,13 @@ snapshots:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
 
-  '@unocss/astro@0.61.5(rollup@4.23.0)(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))':
+  '@unocss/astro@0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))':
     dependencies:
       '@unocss/core': 0.61.5
       '@unocss/reset': 0.61.5
-      '@unocss/vite': 0.61.5(rollup@4.23.0)(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))
+      '@unocss/vite': 0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))
     optionalDependencies:
-      vite: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - rollup
 
@@ -3836,7 +3843,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.61.5
 
-  '@unocss/vite@0.61.5(rollup@4.23.0)(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))':
+  '@unocss/vite@0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.0(rollup@4.23.0)
@@ -3848,24 +3855,24 @@ snapshots:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       magic-string: 0.30.10
-      vite: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - rollup
 
-  '@vitejs/plugin-react@4.3.1(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))':
+  '@vitejs/plugin-react@4.3.1(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.9)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.5(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))':
+  '@vitejs/plugin-vue@5.0.5(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))':
     dependencies:
-      vite: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
       vue: 3.4.32(typescript@5.5.3)
 
   '@vitest/expect@2.0.3':
@@ -5156,9 +5163,9 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.5.4
 
-  unocss@0.61.5(postcss@8.4.47)(rollup@4.23.0)(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)):
+  unocss@0.61.5(postcss@8.4.47)(rollup@4.23.0)(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)):
     dependencies:
-      '@unocss/astro': 0.61.5(rollup@4.23.0)(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))
+      '@unocss/astro': 0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))
       '@unocss/cli': 0.61.5(rollup@4.23.0)
       '@unocss/core': 0.61.5
       '@unocss/extractor-arbitrary-variants': 0.61.5
@@ -5177,9 +5184,9 @@ snapshots:
       '@unocss/transformer-compile-class': 0.61.5
       '@unocss/transformer-directives': 0.61.5
       '@unocss/transformer-variant-group': 0.61.5
-      '@unocss/vite': 0.61.5(rollup@4.23.0)(vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3))
+      '@unocss/vite': 0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3))
     optionalDependencies:
-      vite: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -5201,7 +5208,7 @@ snapshots:
       debug: 4.3.5
       pathe: 1.1.2
       tinyrainbow: 1.2.0
-      vite: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5213,7 +5220,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3):
+  vite@https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.47
@@ -5241,7 +5248,7 @@ snapshots:
       tinybench: 2.8.0
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
-      vite: 6.0.0-beta.2(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@87949fe(@types/node@20.14.11)(terser@5.31.3)
       vite-node: 2.0.3(@types/node@20.14.11)(terser@5.31.3)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
It's time to shorten it from `react-server` to `rsc` for
- https://github.com/vitejs/vite/pull/18255