### PR TITLE
refactor(child-process): use 4th stdio for init ipc

### DIFF
--- a/examples/child-process/src/lib/vite/environment.ts
+++ b/examples/child-process/src/lib/vite/environment.ts
@@ -131,8 +131,7 @@ export class ChildProcessFetchDevEnvironment extends DevEnvironment {
     const url = new URL(request.url);
     const childUrl = new URL(this.childUrl);
     url.host = childUrl.host;
-    // TODO: redirect: "manual"
-    return fetch(new Request(url, { ...request, headers }));
+    return fetch(new Request(url, { ...request, headers, redirect: "manual" }));
   }
 
   /** @internal rpc for runner */

--- a/examples/child-process/src/lib/vite/environment.ts
+++ b/examples/child-process/src/lib/vite/environment.ts
@@ -15,7 +15,6 @@ export class ChildProcessFetchDevEnvironment extends DevEnvironment {
   public bridge!: http.Server;
   public bridgeUrl!: string;
   public child!: childProcess.ChildProcess;
-  public childIO!: readline.Interface;
   public childUrl!: string;
 
   static createFactory(options: {
@@ -106,7 +105,7 @@ export class ChildProcessFetchDevEnvironment extends DevEnvironment {
     );
     this.child = child;
     assert(child.stdio[3] instanceof Readable);
-    this.childIO = readline.createInterface(child.stdio[3]);
+    const childOut = readline.createInterface(child.stdio[3]);
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(
         () => reject(new Error("Child process startup timeout")),
@@ -116,7 +115,7 @@ export class ChildProcessFetchDevEnvironment extends DevEnvironment {
         clearTimeout(timeout);
         reject(e);
       });
-      this.childIO.once("line", (line) => {
+      childOut.once("line", (line) => {
         clearTimeout(timeout);
         try {
           const event = JSON.parse(line);

--- a/examples/child-process/src/lib/vite/environment.ts
+++ b/examples/child-process/src/lib/vite/environment.ts
@@ -116,12 +116,15 @@ export class ChildProcessFetchDevEnvironment extends DevEnvironment {
         clearTimeout(timeout);
         reject(e);
       });
-      this.childIO.on("line", (line) => {
+      this.childIO.once("line", (line) => {
         clearTimeout(timeout);
-        const event = JSON.parse(line);
-        if (event.type === "register") {
+        try {
+          const event = JSON.parse(line);
+          assert(event.type === "register");
           this.childUrl = `http://localhost:${event.port}`;
           resolve();
+        } catch (e) {
+          reject(e);
         }
       });
     });

--- a/examples/child-process/src/lib/vite/environment.ts
+++ b/examples/child-process/src/lib/vite/environment.ts
@@ -46,7 +46,7 @@ export class ChildProcessFetchDevEnvironment extends DevEnvironment {
   override init: DevEnvironment["init"] = async (...args) => {
     await super.init(...args);
 
-    // protect bridgge rpc
+    // protect bridge rpc
     const key = Math.random().toString(36).slice(2);
 
     const listener = webToNodeHandler(async (request) => {
@@ -109,7 +109,7 @@ export class ChildProcessFetchDevEnvironment extends DevEnvironment {
     this.childIO = readline.createInterface(child.stdio[3]);
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(
-        () => reject(new Error("Spawn timeout")),
+        () => reject(new Error("Child process startup timeout")),
         10_000,
       );
       child.on("error", (e) => {
@@ -119,8 +119,10 @@ export class ChildProcessFetchDevEnvironment extends DevEnvironment {
       this.childIO.on("line", (line) => {
         clearTimeout(timeout);
         const event = JSON.parse(line);
-        this.childUrl = `http://localhost:${event.port}`;
-        resolve();
+        if (event.type === "register") {
+          this.childUrl = `http://localhost:${event.port}`;
+          resolve();
+        }
       });
     });
     console.log("[environment.init]", {

--- a/examples/child-process/src/lib/vite/environment.ts
+++ b/examples/child-process/src/lib/vite/environment.ts
@@ -123,12 +123,15 @@ export class ChildProcessFetchDevEnvironment extends DevEnvironment {
     this.bridge?.close();
   };
 
+  // TODO: would be more complicated to do proper proxy?
+  // https://github.com/cloudflare/workers-sdk/blob/e5037b92ac13b1b8a94434e1f9bfa70d4abf791a/packages/miniflare/src/index.ts#L1602
   async dispatchFetch(entry: string, request: Request): Promise<Response> {
     const headers = new Headers(request.headers);
     headers.set("x-vite-meta", JSON.stringify({ entry, url: request.url }));
     const url = new URL(request.url);
     const childUrl = new URL(this.childUrl);
     url.host = childUrl.host;
+    // TODO: redirect: "manual"
     return fetch(new Request(url, { ...request, headers }));
   }
 

--- a/examples/child-process/src/lib/vite/runtime/bun.js
+++ b/examples/child-process/src/lib/vite/runtime/bun.js
@@ -5,7 +5,8 @@ async function main() {
   const options = JSON.parse(process.argv[2]);
   const bridgeClient = createBridgeClient(options);
   const server = Bun.serve({ port: 0, fetch: bridgeClient.handler });
-  await bridgeClient.rpc("register", `http://localhost:${server.port}`);
+  const childOutput = Bun.file(3).writer();
+  childOutput.write(JSON.stringify({ port: server.port }) + "\n");
 }
 
 main();

--- a/examples/child-process/src/lib/vite/runtime/bun.js
+++ b/examples/child-process/src/lib/vite/runtime/bun.js
@@ -6,7 +6,9 @@ async function main() {
   const bridgeClient = createBridgeClient(options);
   const server = Bun.serve({ port: 0, fetch: bridgeClient.handler });
   const childOutput = Bun.file(3).writer();
-  childOutput.write(JSON.stringify({ port: server.port }) + "\n");
+  childOutput.write(
+    JSON.stringify({ type: "register", port: server.port }) + "\n",
+  );
 }
 
 main();

--- a/examples/child-process/src/lib/vite/runtime/bun.js
+++ b/examples/child-process/src/lib/vite/runtime/bun.js
@@ -5,8 +5,8 @@ async function main() {
   const options = JSON.parse(process.argv[2]);
   const bridgeClient = createBridgeClient(options);
   const server = Bun.serve({ port: 0, fetch: bridgeClient.handler });
-  const childOutput = Bun.file(3).writer();
-  childOutput.write(
+  const childOut = Bun.file(3).writer();
+  childOut.write(
     JSON.stringify({ type: "register", port: server.port }) + "\n",
   );
 }

--- a/examples/child-process/src/lib/vite/runtime/node.js
+++ b/examples/child-process/src/lib/vite/runtime/node.js
@@ -16,7 +16,7 @@ async function main() {
     listener(req, res, (e) => console.error(e));
   });
 
-  const childOutput = new Writable({
+  const childOut = new Writable({
     write(chunk, _encoding, callback) {
       fs.write(3, chunk, callback);
     },
@@ -25,7 +25,7 @@ async function main() {
   server.listen(async () => {
     const address = server.address();
     assert(address && typeof address !== "string");
-    childOutput.write(
+    childOut.write(
       JSON.stringify({ type: "register", port: address.port }) + "\n",
     );
   });

--- a/examples/child-process/src/lib/vite/runtime/node.js
+++ b/examples/child-process/src/lib/vite/runtime/node.js
@@ -1,5 +1,7 @@
 import assert from "node:assert";
+import fs from "node:fs";
 import http from "node:http";
+import { Writable } from "node:stream";
 import { webToNodeHandler } from "@hiogawa/utils-node";
 import { createBridgeClient } from "../bridge-client.js";
 
@@ -14,10 +16,16 @@ async function main() {
     listener(req, res, (e) => console.error(e));
   });
 
+  const childOutput = new Writable({
+    write(chunk, _encoding, callback) {
+      fs.write(3, chunk, callback);
+    },
+  });
+
   server.listen(async () => {
     const address = server.address();
     assert(address && typeof address !== "string");
-    await bridgeClient.rpc("register", `http://localhost:${address.port}`);
+    childOutput.write(JSON.stringify({ port: address.port }) + "\n");
   });
 }
 

--- a/examples/child-process/src/lib/vite/runtime/node.js
+++ b/examples/child-process/src/lib/vite/runtime/node.js
@@ -25,7 +25,9 @@ async function main() {
   server.listen(async () => {
     const address = server.address();
     assert(address && typeof address !== "string");
-    childOutput.write(JSON.stringify({ port: address.port }) + "\n");
+    childOutput.write(
+      JSON.stringify({ type: "register", port: address.port }) + "\n",
+    );
   });
 }
 


### PR DESCRIPTION
Reading miniflare to see what it would take to do a proper child process fetch proxying.

## todo

- how does miniflare communicate with workerd process?
  - stdio, 4th pipe! https://github.com/cloudflare/workers-sdk/blob/e5037b92ac13b1b8a94434e1f9bfa70d4abf791a/packages/miniflare/src/runtime/index.ts#L140-L142