### PR TITLE
test: skip flaky on ecosystem ci

### DIFF
--- a/examples/react-server/e2e/basic.test.ts
+++ b/examples/react-server/e2e/basic.test.ts
@@ -280,6 +280,11 @@ test("css hmr server @dev", async ({ page }) => {
 });
 
 test("css hmr client @dev", async ({ page }) => {
+  // flaky?
+  if (process.env["ECOSYSTEM_CI"]) {
+    test.skip();
+  }
+
   usePageErrorChecker(page);
   await page.goto("/");
   await waitForHydration(page);


### PR DESCRIPTION
This suddenly started to fail a lot (e.g. https://github.com/hi-ogawa/vite-environment-examples/pull/133). I guess it's better to sip on ecosystem ci at least.