### PR TITLE
chore(deps): update vite 70bb8de

### DIFF
--- a/examples/react-ssr-workerd/e2e/basic.test.ts
+++ b/examples/react-ssr-workerd/e2e/basic.test.ts
@@ -22,8 +22,8 @@ test("server error stack", async ({ request }) => {
   text = text.replaceAll(process.cwd(), "__CWD__");
   expect(text).toMatch(`\
 Error: crash ssr
-    at Module.crashSsr (__CWD__/src/crash-ssr.ts:7:9)
-    at Module.handler (__CWD__/src/entry-server.tsx:15:5)`);
+    at crashSsr (__CWD__/src/crash-ssr.ts:7:9)
+    at handler (__CWD__/src/entry-server.tsx:15:5)`);
 });
 
 test("hot custom message", async ({ request }) => {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tsup": "^8.1.2",
     "tsx": "^4.16.2",
     "typescript": "^5.5.3",
-    "vite": "6.0.0-beta.3",
+    "vite": "https://pkg.pr.new/vite@70bb8de",
     "vitest": "^2.0.3",
     "wrangler": "^3.79.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: 6.0.0-beta.3
+  vite: https://pkg.pr.new/vite@70bb8de
 
 importers:
 
@@ -22,7 +22,7 @@ importers:
         version: 0.0.2
       '@hiogawa/vite-plugin-ssr-middleware':
         specifier: ^0.0.3
-        version: 0.0.3(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))
+        version: 0.0.3(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))
       '@playwright/test':
         specifier: ^1.45.2
         version: 1.45.2
@@ -40,7 +40,7 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.1(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))
+        version: 4.3.1(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))
       esbuild:
         specifier: ^0.23.0
         version: 0.23.0
@@ -69,8 +69,8 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       vite:
-        specifier: 6.0.0-beta.3
-        version: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+        specifier: https://pkg.pr.new/vite@70bb8de
+        version: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
       vitest:
         specifier: ^2.0.3
         version: 2.0.3(@types/node@20.14.11)(happy-dom@14.12.3)(terser@5.31.3)
@@ -105,7 +105,7 @@ importers:
         version: 0.30.10
       unocss:
         specifier: 0.61.5
-        version: 0.61.5(postcss@8.4.47)(rollup@4.23.0)(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))
+        version: 0.61.5(postcss@8.4.47)(rollup@4.23.0)(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))
 
   examples/react-ssr:
     devDependencies:
@@ -139,7 +139,7 @@ importers:
         version: link:../../packages/workerd
       '@vitejs/plugin-vue':
         specifier: ^5.0.5
-        version: 5.0.5(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))
+        version: 5.0.5(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))
       vue-tsc:
         specifier: ^2.0.26
         version: 2.0.26(typescript@5.5.3)
@@ -164,7 +164,7 @@ importers:
         version: link:../../packages/workerd
       '@vitejs/plugin-vue':
         specifier: ^5.0.5
-        version: 5.0.5(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))
+        version: 5.0.5(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))
       vue-tsc:
         specifier: ^2.0.26
         version: 2.0.26(typescript@5.5.3)
@@ -186,8 +186,8 @@ importers:
   packages/ssr-middleware:
     dependencies:
       vite:
-        specifier: 6.0.0-beta.3
-        version: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+        specifier: https://pkg.pr.new/vite@70bb8de
+        version: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
 
   packages/workerd:
     devDependencies:
@@ -198,8 +198,8 @@ importers:
         specifier: ^3.20240925.0
         version: 3.20240925.0
       vite:
-        specifier: 6.0.0-beta.3
-        version: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+        specifier: https://pkg.pr.new/vite@70bb8de
+        version: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
       wrangler:
         specifier: ^3.79.0
         version: 3.79.0(@cloudflare/workers-types@4.20240925.0)
@@ -1058,8 +1058,9 @@ packages:
 
   '@hiogawa/vite-plugin-ssr-middleware@0.0.3':
     resolution: {integrity: sha512-84bzaAuImty4s4vHjOk5MQMzmDs0W0GP43fOTFhsBfj/MSJCNJ68elmPNZWs57WkIEzcdB4haY/P8Nf4ZGH8Qw==}
+    version: 0.0.3
     peerDependencies:
-      vite: 6.0.0-beta.3
+      vite: https://pkg.pr.new/vite@70bb8de
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -1344,8 +1345,9 @@ packages:
 
   '@unocss/astro@0.61.5':
     resolution: {integrity: sha512-keyh6/EsPMBEiLguaOsh47UcMkWCGT0rW3KV5aYRUfYXlgccSzDd4SLmTNsdlGXIso2XCl/14BJQuwjP0UEU0Q==}
+    version: 0.61.5
     peerDependencies:
-      vite: 6.0.0-beta.3
+      vite: https://pkg.pr.new/vite@70bb8de
     peerDependenciesMeta:
       vite:
         optional: true
@@ -1425,20 +1427,23 @@ packages:
 
   '@unocss/vite@0.61.5':
     resolution: {integrity: sha512-+U5Ey5Z2csjLy7zcaDCtUqs08+ugRK87UWGm65W8yMAGW7me72f36QR8IHJUTqlVVEdhbJVIAy+yNFjGHYffjA==}
+    version: 0.61.5
     peerDependencies:
-      vite: 6.0.0-beta.3
+      vite: https://pkg.pr.new/vite@70bb8de
 
   '@vitejs/plugin-react@4.3.1':
     resolution: {integrity: sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg==}
+    version: 4.3.1
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: 6.0.0-beta.3
+      vite: https://pkg.pr.new/vite@70bb8de
 
   '@vitejs/plugin-vue@5.0.5':
     resolution: {integrity: sha512-LOjm7XeIimLBZyzinBQ6OSm3UBCNVCpLkxGC0oWmm2YPzVZoxMsdvNVimLTBzpAnR9hl/yn1SHGuRfe6/Td9rQ==}
+    version: 5.0.5
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: 6.0.0-beta.3
+      vite: https://pkg.pr.new/vite@70bb8de
       vue: ^3.2.25
 
   '@vitest/expect@2.0.3':
@@ -2664,10 +2669,11 @@ packages:
 
   unocss@0.61.5:
     resolution: {integrity: sha512-BScwlqXW9KHQLKIKtXmwWmMb4Ihoryb7uIgmS+HSqmCN58eqNA73vAo3cZ97xtO+RFdauqgGKP5wD6ShQUvqnQ==}
+    version: 0.61.5
     engines: {node: '>=14'}
     peerDependencies:
       '@unocss/webpack': 0.61.5
-      vite: 6.0.0-beta.3
+      vite: https://pkg.pr.new/vite@70bb8de
     peerDependenciesMeta:
       '@unocss/webpack':
         optional: true
@@ -2688,8 +2694,9 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite@6.0.0-beta.3:
-    resolution: {integrity: sha512-z8hUErPgonMIb0Zir3iquzkaLc5yS1Mnf71LSAxnGpcO60GV3S/NKsYBZ7CGB5mW5UI3slXNjxin6S4SSyPVBQ==}
+  vite@https://pkg.pr.new/vite@70bb8de:
+    resolution: {tarball: https://pkg.pr.new/vite@70bb8de}
+    version: 6.0.0-beta.3
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -3487,9 +3494,9 @@ snapshots:
 
   '@hiogawa/utils@1.7.0': {}
 
-  '@hiogawa/vite-plugin-ssr-middleware@0.0.3(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))':
+  '@hiogawa/vite-plugin-ssr-middleware@0.0.3(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))':
     dependencies:
-      vite: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
 
   '@iconify/types@2.0.0': {}
 
@@ -3736,13 +3743,13 @@ snapshots:
     dependencies:
       '@types/node': 20.14.11
 
-  '@unocss/astro@0.61.5(rollup@4.23.0)(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))':
+  '@unocss/astro@0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))':
     dependencies:
       '@unocss/core': 0.61.5
       '@unocss/reset': 0.61.5
-      '@unocss/vite': 0.61.5(rollup@4.23.0)(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))
+      '@unocss/vite': 0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))
     optionalDependencies:
-      vite: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - rollup
 
@@ -3873,7 +3880,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.61.5
 
-  '@unocss/vite@0.61.5(rollup@4.23.0)(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))':
+  '@unocss/vite@0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.0(rollup@4.23.0)
@@ -3885,24 +3892,24 @@ snapshots:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       magic-string: 0.30.10
-      vite: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - rollup
 
-  '@vitejs/plugin-react@4.3.1(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))':
+  '@vitejs/plugin-react@4.3.1(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.9)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.5(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))':
+  '@vitejs/plugin-vue@5.0.5(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))':
     dependencies:
-      vite: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
       vue: 3.4.32(typescript@5.5.3)
 
   '@vitest/expect@2.0.3':
@@ -5200,9 +5207,9 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.5.4
 
-  unocss@0.61.5(postcss@8.4.47)(rollup@4.23.0)(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)):
+  unocss@0.61.5(postcss@8.4.47)(rollup@4.23.0)(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)):
     dependencies:
-      '@unocss/astro': 0.61.5(rollup@4.23.0)(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))
+      '@unocss/astro': 0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))
       '@unocss/cli': 0.61.5(rollup@4.23.0)
       '@unocss/core': 0.61.5
       '@unocss/extractor-arbitrary-variants': 0.61.5
@@ -5221,9 +5228,9 @@ snapshots:
       '@unocss/transformer-compile-class': 0.61.5
       '@unocss/transformer-directives': 0.61.5
       '@unocss/transformer-variant-group': 0.61.5
-      '@unocss/vite': 0.61.5(rollup@4.23.0)(vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3))
+      '@unocss/vite': 0.61.5(rollup@4.23.0)(vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3))
     optionalDependencies:
-      vite: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -5245,7 +5252,7 @@ snapshots:
       debug: 4.3.5
       pathe: 1.1.2
       tinyrainbow: 1.2.0
-      vite: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5257,7 +5264,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3):
+  vite@https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.47
@@ -5285,7 +5292,7 @@ snapshots:
       tinybench: 2.8.0
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
-      vite: 6.0.0-beta.3(@types/node@20.14.11)(terser@5.31.3)
+      vite: https://pkg.pr.new/vite@70bb8de(@types/node@20.14.11)(terser@5.31.3)
       vite-node: 2.0.3(@types/node@20.14.11)(terser@5.31.3)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
- related https://github.com/vitejs/vite/pull/18329

Update to preview to adapt to new error stack. This also fixes ecosystem ci.