### PR TITLE
refactor: use official async reference

### DIFF
--- a/examples/react-server/src/features/client-component/server.ts
+++ b/examples/react-server/src/features/client-component/server.ts
@@ -10,15 +10,7 @@ import type { BundlerConfig, ImportManifestEntry } from "../../types";
 // name: Counter
 
 export function registerClientReference(id: string, name: string) {
-  // reuse everything but $$async: true for simplicity
-  const reference = ReactServer.registerClientReference({}, id, name);
-  return Object.defineProperties(
-    {},
-    {
-      ...Object.getOwnPropertyDescriptors(reference),
-      $$async: { value: true },
-    },
-  );
+  return ReactServer.registerClientReference({}, id, name);
 }
 
 export function createBundlerConfig(): BundlerConfig {
@@ -30,7 +22,12 @@ export function createBundlerConfig(): BundlerConfig {
         let [id, name] = $$id.split("#");
         tinyassert(id);
         tinyassert(name);
-        return { id, name, chunks: [] } satisfies ImportManifestEntry;
+        return {
+          id,
+          name,
+          chunks: [],
+          async: true,
+        } satisfies ImportManifestEntry;
       },
     },
   );

--- a/examples/react-server/src/features/client-component/ssr.ts
+++ b/examples/react-server/src/features/client-component/ssr.ts
@@ -45,6 +45,7 @@ export function createModuleMap(): ModuleMap {
                 id,
                 name,
                 chunks: [],
+                async: true,
               } satisfies ImportManifestEntry;
             },
           },

--- a/examples/react-server/src/features/server-action/server.ts
+++ b/examples/react-server/src/features/server-action/server.ts
@@ -78,6 +78,7 @@ function createActionBundlerConfig(): BundlerConfig {
           id,
           name,
           chunks: [],
+          async: true,
         } satisfies ImportManifestEntry;
       },
     },

--- a/examples/react-server/src/types/index.ts
+++ b/examples/react-server/src/types/index.ts
@@ -6,8 +6,8 @@
 export interface ImportManifestEntry {
   id: string;
   name: string;
-  // TODO
   chunks: string[];
+  async: boolean;
 }
 
 export interface BundlerConfig {

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -373,8 +373,8 @@ function vitePluginServerAction(): PluginOption {
 
         // make server reference async for simplicity (stale chunkCache, etc...)
         // see TODO in https://github.com/facebook/react/blob/33a32441e991e126e5e874f831bd3afc237a3ecf/packages/react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack.js#L131-L132
-        code = code.replaceAll("if (isAsyncImport(metadata))", "if (true)");
-        code = code.replaceAll("4 === metadata.length", "true");
+        // code = code.replaceAll("if (isAsyncImport(metadata))", "if (true)");
+        // code = code.replaceAll("4 === metadata.length", "true");
 
         return { code, map: null };
       }

--- a/examples/react-server/vite.config.ts
+++ b/examples/react-server/vite.config.ts
@@ -371,11 +371,6 @@ function vitePluginServerAction(): PluginOption {
           "__vite_react_server_webpack_chunk_load__",
         );
 
-        // make server reference async for simplicity (stale chunkCache, etc...)
-        // see TODO in https://github.com/facebook/react/blob/33a32441e991e126e5e874f831bd3afc237a3ecf/packages/react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack.js#L131-L132
-        // code = code.replaceAll("if (isAsyncImport(metadata))", "if (true)");
-        // code = code.replaceAll("4 === metadata.length", "true");
-
         return { code, map: null };
       }
       return;


### PR DESCRIPTION
It looks like we don't need this patch any more, thanks to
- https://github.com/facebook/react/pull/31313

What's left is just to avoid shared `__webpack_require__` in rsc and ssr.