### PR TITLE
ci: fix vite ecosystem ci

### DIFF
--- a/misc/vite-ecosystem-ci.sh
+++ b/misc/vite-ecosystem-ci.sh
@@ -6,10 +6,10 @@ pnpm -C examples/web-worker test-e2e
 pnpm -C examples/web-worker build
 pnpm -C examples/web-worker test-e2e-preview
 
-# workerd environment
-pnpm -C examples/react-ssr-workerd test-e2e
+# # workerd environment
+# pnpm -C examples/react-ssr-workerd test-e2e
 
-# react server environment
-pnpm -C examples/react-server test-e2e
-pnpm -C examples/react-server build
-pnpm -C examples/react-server test-e2e-preview
+# # react server environment
+# pnpm -C examples/react-server test-e2e
+# pnpm -C examples/react-server build
+# pnpm -C examples/react-server test-e2e-preview

--- a/misc/vite-ecosystem-ci.sh
+++ b/misc/vite-ecosystem-ci.sh
@@ -5,11 +5,3 @@ set -eu -o pipefail
 pnpm -C examples/web-worker test-e2e
 pnpm -C examples/web-worker build
 pnpm -C examples/web-worker test-e2e-preview
-
-# # workerd environment
-# pnpm -C examples/react-ssr-workerd test-e2e
-
-# # react server environment
-# pnpm -C examples/react-server test-e2e
-# pnpm -C examples/react-server build
-# pnpm -C examples/react-server test-e2e-preview

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "tsc-dev": "pnpm tsc --watch --preserveWatchOutput",
     "lint": "biome check --write .",
     "lint-check": "biome check .",
-    "vite-ecosystem-ci:build": "pnpm build",
+    "vite-ecosystem-ci:build": "true",
     "vite-ecosystem-ci:before-test": "playwright install chromium",
     "vite-ecosystem-ci:test": "bash misc/vite-ecosystem-ci.sh"
   },


### PR DESCRIPTION
Cloudflare and rsc tests are now covered by official plugins.

Also build is failing https://github.com/vitejs/vite-ecosystem-ci/actions/runs/16560567824/job/46829454246 due to typing, but we don't need build for `examples/web-worker`, so it should be skipped.